### PR TITLE
Use app token for auto-merging bot PRs when CI passes.

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -11,18 +11,24 @@ jobs:
     name: Auto-merge passing bot PRs
     runs-on: ubuntu-latest
     steps:
+      - name: Impersonate auto merge PR bot
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_AUTO_MERGE_PRS_APP_ID }}
+          private_key: ${{ secrets.BOT_AUTO_MERGE_PRS_APP_KEY }}
       - name: Auto-merge passing dependabot PRs
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: ridedott/merge-me-action@v2
         with:
-          # For clarity only. dependabot is default.
+          # For clarity only. dependabot is default login.
           GITHUB_LOGIN: dependabot
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           ENABLED_FOR_MANUAL_CHANGES: "true"
       - name: Auto-merge passing pre-commit-ci PRs
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: ridedott/merge-me-action@v2
         with:
           GITHUB_LOGIN: pre-commit-ci
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           ENABLED_FOR_MANUAL_CHANGES: "true"


### PR DESCRIPTION
I don't think there's a `tox-pytest` action in here yet, so this won't ever run. But it'll be good to have once that workflow is set up.