### PR TITLE
Keep CLI choices in sync with AbstractDatasetArchiver.__subclasses__

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,8 @@ hyperlinks matching the pattern on the page pointed to by the URL. This is usefu
 there's a page containing links to a series of data resources that have somewhat
 structured names.
 
-### Step 2: Add dataset to CLI
-To add support for the dataset in the CLI you have to update the method
-`archive_dataset` in `src/pudl_archiver/cli.py`. Just follow the pattern of the
-other datasets to add this option.
-
-### Step 3: Run --initialize command
-Finally, you will need to run the initialize command to create a new zenodo deposition, and
+### Step 2: Run --initialize command
+You will need to run the initialize command to create a new zenodo deposition, and
 update the config file with the new DOI:
 
 ```

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -28,6 +28,7 @@ def all_archivers():
     ]
     module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles]
     for module in module_names:
+        # AbstractDatasetArchiver won't know about the subclasses unless they are imported
         __import__(module)
     return AbstractDatasetArchiver.__subclasses__()
 

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -21,11 +21,16 @@ import pathlib
 
 def all_archivers():
     dirpath = pathlib.Path(__file__).parent
-    pyfiles = [path.relative_to(dirpath) for path in dirpath.glob("archivers/**/*.py") if "__init__" != path.stem]
-    module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles ]
+    pyfiles = [
+        path.relative_to(dirpath)
+        for path in dirpath.glob("archivers/**/*.py")
+        if "__init__" != path.stem
+    ]
+    module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles]
     for module in module_names:
         __import__(module)
     return AbstractDatasetArchiver.__subclasses__()
+
 
 ARCHIVERS = {archiver.name: archiver for archiver in all_archivers()}
 
@@ -37,7 +42,7 @@ def parse_main():
         "datasets",
         nargs="*",
         help="Name of the Zenodo deposition.",
-        choices=list(ARCHIVERS.keys())
+        choices=list(ARCHIVERS.keys()),
     )
     parser.add_argument(
         "--sandbox",
@@ -59,7 +64,7 @@ async def archive_dataset(
     initialize: bool = False,
 ):
     """Download and archive dataset on zenodo."""
-    
+
     async with zenodo_client.deposition_interface(name, initialize) as deposition:
         # Create new deposition then return
         cls = ARCHIVERS.get(name)

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -10,22 +10,24 @@ import aiohttp
 import coloredlogs
 from dotenv import load_dotenv
 
-from pudl_archiver.archivers.censusdp1tract import CensusDp1TractArchiver
-from pudl_archiver.archivers.eia860 import Eia860Archiver
-from pudl_archiver.archivers.eia860m import Eia860MArchiver
-from pudl_archiver.archivers.eia861 import Eia861Archiver
-from pudl_archiver.archivers.eia923 import Eia923Archiver
-from pudl_archiver.archivers.eia_bulk_elec import EiaBulkElecArchiver
-from pudl_archiver.archivers.epacamd_eia import EpaCamdEiaArchiver
-from pudl_archiver.archivers.epacems import EpaCemsArchiver
-from pudl_archiver.archivers.ferc.ferc1 import Ferc1Archiver
-from pudl_archiver.archivers.ferc.ferc2 import Ferc2Archiver
-from pudl_archiver.archivers.ferc.ferc6 import Ferc6Archiver
-from pudl_archiver.archivers.ferc.ferc60 import Ferc60Archiver
-from pudl_archiver.archivers.ferc.ferc714 import Ferc714Archiver
+from pudl_archiver.archivers.classes import AbstractDatasetArchiver
 from pudl_archiver.zenodo.api_client import ZenodoClient
 
 logger = logging.getLogger("catalystcoop.pudl_archiver")
+
+
+import pathlib
+
+
+def all_archivers():
+    dirpath = pathlib.Path(__file__).parent
+    pyfiles = [path.relative_to(dirpath) for path in dirpath.glob("archivers/**/*.py") if "__init__" != path.stem]
+    module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles ]
+    for module in module_names:
+        __import__(module)
+    return AbstractDatasetArchiver.__subclasses__()
+
+ARCHIVERS = {archiver.name: archiver for archiver in all_archivers()}
 
 
 def parse_main():
@@ -34,9 +36,8 @@ def parse_main():
     parser.add_argument(
         "datasets",
         nargs="*",
-        help="Name of the Zenodo deposition. Supported: censusdp1tract, "
-        "eia860, eia861, eia923, eia_bulk_elec, epacems, epacamd_eia, "
-        "ferc1, ferc2, ferc6, ferc60, ferc714, eia860m",
+        help="Name of the Zenodo deposition.",
+        choices=list(ARCHIVERS.keys())
     )
     parser.add_argument(
         "--sandbox",
@@ -58,38 +59,14 @@ async def archive_dataset(
     initialize: bool = False,
 ):
     """Download and archive dataset on zenodo."""
+    
     async with zenodo_client.deposition_interface(name, initialize) as deposition:
         # Create new deposition then return
-        match name:
-            case "ferc1":
-                archiver = Ferc1Archiver(session, deposition)
-            case "ferc2":
-                archiver = Ferc2Archiver(session, deposition)
-            case "ferc6":
-                archiver = Ferc6Archiver(session, deposition)
-            case "ferc60":
-                archiver = Ferc60Archiver(session, deposition)
-            case "ferc714":
-                archiver = Ferc714Archiver(session, deposition)
-            case "censusdp1tract":
-                archiver = CensusDp1TractArchiver(session, deposition)
-            case "eia860":
-                archiver = Eia860Archiver(session, deposition)
-            case "eia860m":
-                archiver = Eia860MArchiver(session, deposition)
-            case "eia861":
-                archiver = Eia861Archiver(session, deposition)
-            case "eia923":
-                archiver = Eia923Archiver(session, deposition)
-            case "eia_bulk_elec":
-                archiver = EiaBulkElecArchiver(session, deposition)
-            case "epacems":
-                archiver = EpaCemsArchiver(session, deposition)
-            case "epacamd_eia":
-                archiver = EpaCamdEiaArchiver(session, deposition)
-            case _:
-                raise RuntimeError("Dataset not supported")
-
+        cls = ARCHIVERS.get(name)
+        if not cls:
+            raise RuntimeError("Dataset not supported")
+        else:
+            archiver = cls(session, deposition)
         await archiver.create_archive()
 
 

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import logging
 import os
+import pathlib
 
 import aiohttp
 import coloredlogs
@@ -16,10 +17,8 @@ from pudl_archiver.zenodo.api_client import ZenodoClient
 logger = logging.getLogger("catalystcoop.pudl_archiver")
 
 
-import pathlib
-
-
 def all_archivers():
+    """List all Archivers that have been defined."""
     dirpath = pathlib.Path(__file__).parent
     pyfiles = [
         path.relative_to(dirpath)
@@ -65,7 +64,6 @@ async def archive_dataset(
     initialize: bool = False,
 ):
     """Download and archive dataset on zenodo."""
-
     async with zenodo_client.deposition_interface(name, initialize) as deposition:
         # Create new deposition then return
         cls = ARCHIVERS.get(name)

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -68,7 +68,7 @@ async def archive_dataset(
         # Create new deposition then return
         cls = ARCHIVERS.get(name)
         if not cls:
-            raise RuntimeError("Dataset not supported")
+            raise RuntimeError(f"Dataset {name} not supported")
         else:
             archiver = cls(session, deposition)
         await archiver.create_archive()
@@ -81,10 +81,10 @@ async def archive_datasets():
 
     if args.sandbox:
         upload_key = os.environ["ZENODO_SANDBOX_TOKEN_UPLOAD"]
-        publish_key = os.environ["ZENODO_SANDBOX_TOKEN_UPLOAD"]
+        publish_key = os.environ["ZENODO_SANDBOX_TOKEN_PUBLISH"]
     else:
         upload_key = os.environ["ZENODO_TOKEN_UPLOAD"]
-        publish_key = os.environ["ZENODO_TOKEN_UPLOAD"]
+        publish_key = os.environ["ZENODO_TOKEN_PUBLISH"]
 
     connector = aiohttp.TCPConnector(limit_per_host=20, force_close=True)
     async with aiohttp.ClientSession(


### PR DESCRIPTION
Just some refactoring I did while I was mucking around making sense of the code.

Basically this just looks at `AbstractDatasetArchiver` and grabs all its subclasses - they need to get `import`ed first before they become registered on the base class, though, hence that weird `__import__` thing.

That makes it so that we can just add the Archiver subclasses and not worry about updating the CLI - which is a trivial worry, but maybe a nice quality-of-life thing to have.

If this seems like not a useful thing I'm happy to close it too - this was mainly for my own learning/orientation.