### PR TITLE
Add dry run

### DIFF
--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -1,1 +1,75 @@
 """Tool to download data resources and create archives on Zenodo for use in PUDL."""
+import asyncio
+import os
+import pathlib
+
+import aiohttp
+
+from pudl_archiver.archivers.classes import AbstractDatasetArchiver
+from pudl_archiver.zenodo.api_client import ZenodoClient
+
+
+def all_archivers():
+    """List all Archivers that have been defined."""
+    dirpath = pathlib.Path(__file__).parent
+    pyfiles = [
+        path.relative_to(dirpath)
+        for path in dirpath.glob("archivers/**/*.py")
+        if "__init__" != path.stem
+    ]
+    module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles]
+    for module in module_names:
+        # AbstractDatasetArchiver won't know about the subclasses unless they are imported
+        __import__(module)
+    return AbstractDatasetArchiver.__subclasses__()
+
+
+ARCHIVERS = {archiver.name: archiver for archiver in all_archivers()}
+
+
+async def archive_dataset(
+    name: str,
+    zenodo_client: ZenodoClient,
+    session: aiohttp.ClientSession,
+    initialize: bool = False,
+):
+    """Download and archive dataset on zenodo."""
+    async with zenodo_client.deposition_interface(name, initialize) as deposition:
+        # Create new deposition then return
+        cls = ARCHIVERS.get(name)
+        if not cls:
+            raise RuntimeError(f"Dataset {name} not supported")
+        else:
+            archiver = cls(session, deposition)
+        await archiver.create_archive()
+
+
+async def archive_datasets(datasets, sandbox, initialize):
+    """A CLI for the PUDL Zenodo Storage system."""
+    if sandbox:
+        upload_key = os.environ["ZENODO_SANDBOX_TOKEN_UPLOAD"]
+        publish_key = os.environ["ZENODO_SANDBOX_TOKEN_PUBLISH"]
+    else:
+        upload_key = os.environ["ZENODO_TOKEN_UPLOAD"]
+        publish_key = os.environ["ZENODO_TOKEN_PUBLISH"]
+
+    connector = aiohttp.TCPConnector(limit_per_host=20, force_close=True)
+    async with aiohttp.ClientSession(
+        connector=connector, raise_for_status=True
+    ) as session:
+        # List to gather all archivers to run asyncronously
+        tasks = []
+        for dataset in datasets:
+            zenodo_client = ZenodoClient(
+                "dataset_doi.yaml",
+                session,
+                upload_key,
+                publish_key,
+                testing=sandbox,
+            )
+
+            tasks.append(
+                archive_dataset(dataset, zenodo_client, session, initialize=initialize)
+            )
+
+        await asyncio.gather(*tasks)

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -32,9 +32,12 @@ async def archive_dataset(
     zenodo_client: ZenodoClient,
     session: aiohttp.ClientSession,
     initialize: bool = False,
+    dry_run: bool = True,
 ):
     """Download and archive dataset on zenodo."""
-    async with zenodo_client.deposition_interface(name, initialize) as deposition:
+    async with zenodo_client.deposition_interface(
+        name, initialize, dry_run=dry_run
+    ) as deposition:
         # Create new deposition then return
         cls = ARCHIVERS.get(name)
         if not cls:
@@ -44,7 +47,12 @@ async def archive_dataset(
         await archiver.create_archive()
 
 
-async def archive_datasets(datasets, sandbox, initialize):
+async def archive_datasets(
+    datasets: list[str],
+    sandbox: bool = True,
+    initialize: bool = False,
+    dry_run: bool = True,
+):
     """A CLI for the PUDL Zenodo Storage system."""
     if sandbox:
         upload_key = os.environ["ZENODO_SANDBOX_TOKEN_UPLOAD"]
@@ -69,7 +77,13 @@ async def archive_datasets(datasets, sandbox, initialize):
             )
 
             tasks.append(
-                archive_dataset(dataset, zenodo_client, session, initialize=initialize)
+                archive_dataset(
+                    dataset,
+                    zenodo_client,
+                    session,
+                    initialize=initialize,
+                    dry_run=dry_run,
+                )
             )
 
         await asyncio.gather(*tasks)

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -32,6 +32,11 @@ def parse_main():
         action="store_true",
         help="Initialize new deposition by preserving a DOI",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip actually uploading to Zenodo",
+    )
     return parser.parse_args()
 
 

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -4,35 +4,13 @@
 import argparse
 import asyncio
 import logging
-import os
-import pathlib
 
-import aiohttp
 import coloredlogs
 from dotenv import load_dotenv
 
-from pudl_archiver.archivers.classes import AbstractDatasetArchiver
-from pudl_archiver.zenodo.api_client import ZenodoClient
+from pudl_archiver import ARCHIVERS, archive_datasets
 
 logger = logging.getLogger("catalystcoop.pudl_archiver")
-
-
-def all_archivers():
-    """List all Archivers that have been defined."""
-    dirpath = pathlib.Path(__file__).parent
-    pyfiles = [
-        path.relative_to(dirpath)
-        for path in dirpath.glob("archivers/**/*.py")
-        if "__init__" != path.stem
-    ]
-    module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles]
-    for module in module_names:
-        # AbstractDatasetArchiver won't know about the subclasses unless they are imported
-        __import__(module)
-    return AbstractDatasetArchiver.__subclasses__()
-
-
-ARCHIVERS = {archiver.name: archiver for archiver in all_archivers()}
 
 
 def parse_main():
@@ -57,67 +35,15 @@ def parse_main():
     return parser.parse_args()
 
 
-async def archive_dataset(
-    name: str,
-    zenodo_client: ZenodoClient,
-    session: aiohttp.ClientSession,
-    initialize: bool = False,
-):
-    """Download and archive dataset on zenodo."""
-    async with zenodo_client.deposition_interface(name, initialize) as deposition:
-        # Create new deposition then return
-        cls = ARCHIVERS.get(name)
-        if not cls:
-            raise RuntimeError(f"Dataset {name} not supported")
-        else:
-            archiver = cls(session, deposition)
-        await archiver.create_archive()
-
-
-async def archive_datasets():
-    """A CLI for the PUDL Zenodo Storage system."""
-    args = parse_main()
-    load_dotenv()
-
-    if args.sandbox:
-        upload_key = os.environ["ZENODO_SANDBOX_TOKEN_UPLOAD"]
-        publish_key = os.environ["ZENODO_SANDBOX_TOKEN_PUBLISH"]
-    else:
-        upload_key = os.environ["ZENODO_TOKEN_UPLOAD"]
-        publish_key = os.environ["ZENODO_TOKEN_PUBLISH"]
-
-    connector = aiohttp.TCPConnector(limit_per_host=20, force_close=True)
-    async with aiohttp.ClientSession(
-        connector=connector, raise_for_status=True
-    ) as session:
-        # List to gather all archivers to run asyncronously
-        tasks = []
-        for dataset in args.datasets:
-            zenodo_client = ZenodoClient(
-                "dataset_doi.yaml",
-                session,
-                upload_key,
-                publish_key,
-                testing=args.sandbox,
-            )
-
-            tasks.append(
-                archive_dataset(
-                    dataset, zenodo_client, session, initialize=args.initialize
-                )
-            )
-
-        await asyncio.gather(*tasks)
-
-
 def main():
     """Run desired archivers."""
+    load_dotenv()
     logger.setLevel(logging.INFO)
     log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
     coloredlogs.install(fmt=log_format, level=logging.INFO, logger=logger)
 
-    asyncio.run(archive_datasets())
+    asyncio.run(archive_datasets(**vars(parse_main())))
 
 
-if __name__ == "main":
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add a `--dry-run` mode so that I can more safely test the automated runs.

* move "actually do archiving" logic into `__init__.py` and out of `cli.py` - in preparation for maybe doing some programmatic access later.
* add `dry_run` attribute to the `ZenodoDepositionInterface` so we can check if we're running dry or wet.
* change `ZenodoDepositionInterface` to the "collect a bunch of IO things to do, then do all the IO in one place" pattern to make dry-run checks easier

I could imagine trying to separate the IO and the logic even more, that would help the testing as well - e.g. some sort of `DepositionDiffer` that can take deposition info from anywhere and produces a changeset, then some sort of `ZenodoThingDoer` that produces deposition info and also applies a changeset. In testing you could just pass stuff in and investigate the changesets produced.