### PR TITLE
Github Action to run `pudl_archiver` regularly

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -1,0 +1,46 @@
+---
+name: run-archiver
+
+on: push
+
+jobs:
+  run-archiver:
+    strategy:
+      matrix:
+        dataset_group:
+          - [eia860, eia861]
+          - [ferc1, ferc2]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Set up conda environment for testing
+        uses: conda-incubator/setup-miniconda@v2.1.1
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+          python-version: "3.10"
+          activate-environment: pudl-archiver
+          environment-file: environment.yml
+
+      - shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+
+      - name: Run archiver for ${{ matrix.dataset_group }}
+        env:
+          ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
+          ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+        run: |
+          conda run -n pudl-archiver pudl_archiver --sandbox --datasets ${{ join(matrix.dataset_group, ' ') }}

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -1,7 +1,7 @@
 ---
 name: run-archiver
 
-on: push
+on: workflow_dispatch
 
 jobs:
   run-archiver:
@@ -38,7 +38,7 @@ jobs:
           conda config --show
           printenv | sort
 
-      - name: Run archiver for ${{ matrix.dataset_group }}
+      - name: Run archiver for ${{ join(matrix.dataset_group, ', ') }}
         env:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -4,12 +4,12 @@ name: run-archiver
 on: workflow_dispatch
 
 jobs:
-  run-archiver:
+  archive-run:
     strategy:
       matrix:
         dataset_group:
-          - [eia860, eia861]
-          - [ferc1, ferc2]
+          - [eia860]
+          - [eia861]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -44,3 +44,27 @@ jobs:
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
         run: |
           conda run -n pudl-archiver pudl_archiver --sandbox --datasets ${{ join(matrix.dataset_group, ' ') }}
+
+  archive-notify:
+    runs-on: ubuntu-latest
+    needs: archive-run
+    if: ${{ always() }}
+    steps:
+      - name: Inform the Codemonkeys
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+              username: 'action-slack',
+              icon_emoji: ':octocat:',
+              attachments: [{
+                color: '${{ needs.archive-run.result }}' === 'success' ? 'good' : '${{ needs.archive-run.result }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_REPO}@${process.env.AS_REF}\n ${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT})\n by ${process.env.AS_AUTHOR}\n Status: ${{ needs.archive-run.result }}`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }} # required
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -1,7 +1,7 @@
 ---
 name: tox-pytest
 
-on: [push, pull_request]
+on: push
 
 jobs:
   ci-test:
@@ -24,7 +24,7 @@ jobs:
           channels: conda-forge,defaults
           channel-priority: true
           python-version: "3.10"
-          activate-environment: pudl-scrapers
+          activate-environment: pudl-archiver
           environment-file: environment.yml
       - shell: bash -l {0}
         run: |
@@ -39,7 +39,7 @@ jobs:
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
         run: |
-          conda run -n pudl-scrapers tox
+          conda run -n pudl-archiver tox
 
       - name: Upload test coverage report to CodeCov
         uses: codecov/codecov-action@v3.1.1

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ conda activate pudl-archiver
 A CLI is provided for creating and updating archives. The basic usage looks like:
 
 ```
-pudl_archiver {list_of_datasources}
+pudl_archiver --datasets {list_of_datasources}
 ```
 
 This command will download the latest available data and create archives for each
@@ -58,12 +58,15 @@ requested datasource requested. The supported datasources include `eia860`, `eia
 `eia_bulk_elec`, `epacems`, `epacamd_eia`, `ferc1`, `ferc2`, `ferc6`, `ferc60`,
 `ferc714`, `eia860m`.
 
-There are also two optional flags available, `--sandbox` and `--initialize`. The
-sandbox flag is used for testing. It will only interact with Zenodo's
-[sandbox](https://sandbox.zenodo.org/) instance. The initialize flag is used when
-creating an archive for a new dataset that doesn't currently exist on zenodo.
-If successful, this command will automatically add the new Zenodo DOI to the
-`dataset_doi.yaml` file.
+There are also four optional flags available:
+* `--sandbox`: used for testing. It will only interact with Zenodo's
+  [sandbox](https://sandbox.zenodo.org/) instance.
+* `--initialize`: used for creating an archive for a new dataset that doesn't
+  currently exist on zenodo. If successful, this command will automatically add
+  the new Zenodo DOI to the `dataset_doi.yaml` file.
+* `--dry-run`: used for testing, it ignores all Zenodo write operations.
+* `--all`: shortcut for archiving all datasets that we have defined archivers
+  for. Overrides `--datasets`.
 
 
 ## Adding a new dataset
@@ -111,5 +114,5 @@ You will need to run the initialize command to create a new zenodo deposition, a
 update the config file with the new DOI:
 
 ```
-pudl_archiver {new_dataset_name} --initialize
+pudl_archiver --datasets {new_dataset_name} --initialize
 ```

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -17,10 +17,15 @@ def parse_main():
     """Process base commands from the CLI."""
     parser = argparse.ArgumentParser(description="Upload PUDL data archives to Zenodo")
     parser.add_argument(
-        "datasets",
+        "--datasets",
         nargs="*",
         help="Name of the Zenodo deposition.",
         choices=list(ARCHIVERS.keys()),
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all defined archivers.",
     )
     parser.add_argument(
         "--sandbox",
@@ -46,8 +51,11 @@ def main():
     logger.setLevel(logging.INFO)
     log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
     coloredlogs.install(fmt=log_format, level=logging.INFO, logger=logger)
-
-    asyncio.run(archive_datasets(**vars(parse_main())))
+    args = parse_main()
+    if args.all:
+        args.datasets = ARCHIVERS.keys()
+    del args.all
+    asyncio.run(archive_datasets(**vars(args)))
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -95,12 +95,12 @@ skip_install = false
 recreate = true
 extras =
     {[testenv:linters]extras}
-    # {[testenv:unit]extras}
+    {[testenv:unit]extras}
 commands =
     coverage erase
     {[testenv:linters]commands}
-    # {[testenv:unit]commands}
-    # {[testenv]covreport}
+    {[testenv:unit]commands}
+    {[testenv]covreport}
 
 #######################################################################################
 # Configuration for various tools.

--- a/tox.ini
+++ b/tox.ini
@@ -95,12 +95,12 @@ skip_install = false
 recreate = true
 extras =
     {[testenv:linters]extras}
-    {[testenv:unit]extras}
+    # {[testenv:unit]extras}
 commands =
     coverage erase
     {[testenv:linters]commands}
-    {[testenv:unit]commands}
-    {[testenv]covreport}
+    # {[testenv:unit]commands}
+    # {[testenv]covreport}
 
 #######################################################################################
 # Configuration for various tools.


### PR DESCRIPTION
This adds a github action that creates the conda env and runs `pudl_archiver`.

It allows for some parallelism in builds - we can define that via the `dataset_groups` setting on the `job.strategy`.

Some things before this becomes fully "production":
* [ ] give it the non-sandbox credentials
* [ ] add the rest of the datasets
* [ ] schedule weekly