### PR TITLE
Create dedicated Zenodo interaction class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dev = [
     "isort>=5.0,<5.11",  # Standardized import sorting
     "tox>=3.20,<3.27",  # Python test environment manager
     "twine>=3.3,<4.1",  # Used to make releases to PyPI
+    "mypy",
+    "types-requests",
 ]
 
 

--- a/src/pudl_archiver/depositors/__init__.py
+++ b/src/pudl_archiver/depositors/__init__.py
@@ -1,0 +1,6 @@
+"""Interact with data depositions in all the backends we use.
+
+Such as Zenodo, Zenodo, and Zenodo.
+"""
+
+from pudl_archiver.depositors.zenodo import ZenodoDepositor  # noqa: F401

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -1,7 +1,7 @@
 """Handle all deposition actions within Zenodo."""
 import json
 import logging
-from typing import BinaryIO
+from typing import BinaryIO, Literal
 
 import aiohttp
 import semantic_version  # type: ignore
@@ -68,7 +68,11 @@ class ZenodoDepositor:
         """Wraps our session requests with some Zenodo-specific error handling."""
 
         async def requester(
-            method: str, url: str, log_label: str, parse_json: bool = True, **kwargs
+            method: Literal["GET", "POST", "PUT", "DELETE"],
+            url: str,
+            log_label: str,
+            parse_json: bool = True,
+            **kwargs,
         ) -> dict | aiohttp.ClientResponse:
             """Make requests to Zenodo.
 
@@ -264,7 +268,7 @@ class ZenodoDepositor:
         deposition: Deposition,
         target: str,
         data: BinaryIO,
-        force_api: str | None = None,
+        force_api: Literal["bucket", "files"] | None = None,
     ) -> None:
         """Create a file in a deposition.
 

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -1,0 +1,159 @@
+"""Handle all deposition actions within Zenodo."""
+# TODO (daz): fix flake8 so it stops asking for so many repetitive docstrings.
+from typing import IO
+
+import aiohttp
+
+from pudl_archiver.zenodo.entities import Deposition, DepositionMetadata
+
+
+# TODO (daz): start using mypy on this file.
+class ZenodoClientException(Exception):
+    """Captures the JSON error information from Zenodo."""
+
+    def __init__(self, kwargs):
+        """Constructor.
+
+        Args:
+            kwargs: dictionary with "response" mapping to the actual
+                aiohttp.ClientResponse and "json" mapping to the JSON content.
+        """
+        self.kwargs = kwargs
+        self.status = kwargs["response"].status
+        self.message = kwargs["json"].get("message", {})
+        self.errors = kwargs["json"].get("errors", {})
+
+    def __str__(self):
+        """The JSON has all we really care about."""
+        return f"ZenodoClientException({self.kwargs['json']})"
+
+    def __repr__(self):
+        """But the kwargs are useful for recreating this object."""
+        return f"ZenodoClientException({repr(self.kwargs)})"
+
+
+class ZenodoDepositor:
+    """Deposition actions within Zenodo.
+
+    * manipulate depositions & their versions
+    * manipulate files within depositions
+    """
+
+    def __init__(
+        self, upload_key: str, publish_key: str, session: aiohttp.ClientSession
+    ):
+        """Constructor.
+
+        Args:
+            upload_key: the Zenodo API key that gives you upload rights.
+            publish_key: the Zenodo API key that gives you publish rights.
+            session: HTTP handler - we don't use it directly, it's wrapped in self.request.
+        """
+        self.upload_key = upload_key
+        self.publish_key = publish_key
+        self.requester = self._make_requester(session)
+
+    def _make_requester(self, session):
+        """Wraps our session requests with some Zenodo-specific error handling."""
+
+        async def requester(*args, **kwargs):
+            # Doesn't get a reference to self!
+            async with session.get(*args, **kwargs) as response:
+                resp_json = await response.json(**kwargs)
+                if response.status >= 400:
+                    raise ZenodoClientException(
+                        {"response": response, "json": resp_json}
+                    )
+                return resp_json
+
+        return requester
+
+    def create_deposition(self, deposition_metadata: DepositionMetadata) -> Deposition:
+        """Create a whole new deposition.
+
+        Args:
+            deposition_metadata: a metadata, to make a deposition with.
+        """
+        raise NotImplementedError
+
+    def get_deposition(self, concept_doi: str) -> Deposition:
+        """Get a deposition from a concept DOI.
+
+        Args:
+            concept_doi: the DOI for the concept - gets the latest associated DOI.
+        """
+        # TODO (daz): do we ever need to get a deposition from a normal DOI?
+        raise NotImplementedError
+
+    def get_new_version(self, deposition: Deposition) -> Deposition:
+        """Get a new version of a deposition.
+
+        Args:
+            deposition: the deposition you want to get the new version of.
+        """
+        raise NotImplementedError
+
+    def publish_deposition(self, deposition: Deposition) -> Deposition:
+        """Publish a deposition.
+
+        Needs to have at least one file, and needs to not already be published.
+
+        Args:
+            deposition: the deposition you want to publish.
+        """
+        raise NotImplementedError
+
+    # TODO (daz): should we represent the edit/no-edit state in the Deposition?
+    # TODO (daz): should we return a success/failure flag instead of None/error?
+    def discard_deposition(self, deposition: Deposition) -> None:
+        """Discard a deposition.
+
+        This deposition must either be un-published or in the editing state.
+
+        Args:
+            deposition: the deposition you want to discard.
+
+        Returns:
+            None if success.
+        """
+        raise NotImplementedError
+
+    def delete_file(self, deposition: Deposition, target: str) -> None:
+        """Delete a file from a deposition.
+
+        Args:
+            deposition: the deposition you are applying this change to.
+            target: the filename of the file you want to delete.
+
+        Returns:
+            None if success.
+        """
+        raise NotImplementedError
+
+    # TODO (daz): is data actually type BinaryIO?
+    def create_file(self, deposition: Deposition, target: str, data: IO) -> None:
+        """Create a file in a deposition.
+
+        Args:
+            deposition: the deposition you are applying this change to.
+            target: the filename of the file you want to delete.
+            data: the actual data associated with the file.
+
+        Returns:
+            None if success.
+        """
+        raise NotImplementedError
+
+    def update_file(self, deposition: Deposition, target: str, data: IO) -> None:
+        """Update a file in a deposition.
+
+        Args:
+            deposition: the deposition you are applying this change to.
+            target: the filename of the file you want to delete.
+            data: the actual data associated with the file.
+
+        Returns:
+            None if success.
+        """
+        self.delete_file(deposition, target)
+        self.create_file(deposition, target, data)

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -150,9 +150,10 @@ class ZenodoDepositor:
             params=params,
             headers=self.auth_write,
         )
-        if len(response) > 1 and not self.sandbox:
-            # TODO (daz): not convinced we can't just always pick the most recent one.
-            raise RuntimeError("Zenodo should only return a single deposition")
+        if len(response) > 1:
+            logger.info(
+                f"{concept_doi} points at multiple records: {[r['id'] for r in response]}"
+            )
 
         latest_deposition = Deposition(**sorted(response, key=lambda d: d["id"])[-1])
         full_deposition_json = await self.request(

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -1,0 +1,88 @@
+import os
+
+import aiohttp
+import pytest
+import pytest_asyncio
+from dotenv import load_dotenv
+
+from pudl_archiver.depositors import ZenodoDepositor
+from pudl_archiver.frictionless import DataPackage
+from pudl_archiver.zenodo.entities import DepositionCreator, DepositionMetadata
+
+
+@pytest.fixture()
+def dotenv():
+    """Load dotenv to get API keys."""
+    load_dotenv()
+
+
+@pytest.fixture()
+def upload_key(dotenv):
+    """Get upload key."""
+    return os.environ["ZENODO_SANDBOX_TOKEN_UPLOAD"]
+
+
+@pytest.fixture()
+def publish_key(dotenv):
+    """Get publish key."""
+    return os.environ["ZENODO_SANDBOX_TOKEN_PUBLISH"]
+
+
+@pytest.fixture()
+def deposition_metadata():
+    """Create fake DepositionMetadata model."""
+    return DepositionMetadata(
+        title="PUDL Test",
+        creators=[
+            DepositionCreator(
+                name="catalyst-cooperative", affiliation="Catalyst Cooperative"
+            )
+        ],
+        description="Test dataset for the sandbox, thanks!",
+        version="1.0.0",
+        license="CC0-1.0",
+        keywords=["test"],
+    )
+
+
+@pytest.fixture()
+def datapackage():
+    """Create test datapackage descriptor."""
+    return DataPackage(
+        name="pudl_test",
+        title="PUDL Test",
+        description="Test dataset for the sandbox, thanks!",
+        keywords=[],
+        contributors=[],
+        sources=[],
+        licenses=[],
+        resources=[],
+        created="2023-01-17T20:57:05.000000Z",
+    )
+
+
+@pytest_asyncio.fixture()
+async def session():
+    """Create async http session."""
+    async with aiohttp.ClientSession(raise_for_status=True) as session:
+        yield session
+
+
+@pytest.fixture()
+def depositor(upload_key, publish_key, session):
+    return ZenodoDepositor(upload_key, publish_key, session, sandbox=True)
+
+
+def clean_metadata(metadata):
+    return metadata.dict(
+        by_alias=True,
+        exclude={"publication_date", "doi", "prereserve_doi"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_deposition(depositor, deposition_metadata):
+    deposition = await depositor.create_deposition(deposition_metadata)
+
+    assert clean_metadata(deposition.metadata) == clean_metadata(deposition_metadata)
+    assert deposition.state == "unsubmitted"

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -1,11 +1,14 @@
 import os
+from io import BytesIO
 
 import aiohttp
 import pytest
 import pytest_asyncio
+import requests
 from dotenv import load_dotenv
 
 from pudl_archiver.depositors import ZenodoDepositor
+from pudl_archiver.depositors.zenodo import ZenodoClientException
 from pudl_archiver.frictionless import DataPackage
 from pudl_archiver.zenodo.entities import DepositionCreator, DepositionMetadata
 
@@ -64,7 +67,7 @@ def datapackage():
 @pytest_asyncio.fixture()
 async def session():
     """Create async http session."""
-    async with aiohttp.ClientSession(raise_for_status=True) as session:
+    async with aiohttp.ClientSession() as session:
         yield session
 
 
@@ -81,25 +84,88 @@ def clean_metadata(metadata):
 
 
 @pytest.mark.asyncio
-async def test_create_deposition(depositor, deposition_metadata):
+async def test_full_zenodo_flow(depositor, deposition_metadata, upload_key):
+    # create deposition
     deposition = await depositor.create_deposition(deposition_metadata)
 
     assert clean_metadata(deposition.metadata) == clean_metadata(deposition_metadata)
     assert deposition.state == "unsubmitted"
 
+    # try publishing empty
+    with pytest.raises(ZenodoClientException) as excinfo:
+        await depositor.publish_deposition(deposition)
+    error_json = excinfo.value.kwargs["json"]
+    assert "validation error" in error_json["message"].lower()
+    assert (
+        "minimum one file must be provided"
+        in error_json["errors"][0]["message"].lower()
+    )
 
-@pytest.mark.asyncio
-async def test_get_deposition(depositor, deposition_metadata):
-    pass
-    # commented these out so I can commit.
-    # deposition = await depositor.create_deposition(deposition_metadata)
-    # TODO (daz): guess we need to add files and publish, before it gets a concept
-    # depositor.create_file()
-    # depositor.publish()
-    # we should probably make just one deposition and do a bunch of stuff to it.
-    # this means we also need to implement get by specific doi.
+    conceptrecid = deposition.conceptrecid
 
-    # concept_doi = deposition.conceptdoi
-    # assert concept_doi is not None, "has a concept_doi"
-    # latest_deposition = await depositor.get_deposition(concept_doi)
-    # assert latest_deposition._id == deposition._id
+    # add files to initial deposition
+    initial_files = {
+        "to_update": b"I am outdated",
+        "to_delete": b"Delete me!",
+    }
+
+    await depositor.create_file(
+        deposition, "to_update", BytesIO(initial_files["to_update"]), force_api="files"
+    )
+    await depositor.create_file(
+        deposition, "to_delete", BytesIO(initial_files["to_delete"])
+    )
+
+    # publish initial deposition
+    published_deposition = await depositor.publish_deposition(deposition)
+    assert published_deposition.conceptdoi.rsplit(".", 1)[1] == conceptrecid
+    assert published_deposition.id_ == deposition.id_
+    assert published_deposition.state == "done"
+
+    conceptdoi = published_deposition.conceptdoi
+
+    # verify that the first version has the files we expect
+    v1_files = published_deposition.files
+    assert len(v1_files) == 2
+
+    for deposition_file in v1_files:
+        download_link = deposition_file.links.download
+        expected_contents = initial_files[deposition_file.filename]
+
+        remote_contents = requests.get(
+            download_link, headers={"Authorization": f"bearer {upload_key}"}
+        )
+        assert expected_contents == remote_contents.text.encode("utf-8")
+
+    # check that the latest deposition in the conceptdoi points at the one we just published
+    latest_deposition = await depositor.get_deposition(conceptdoi)
+    assert latest_deposition.id_ == published_deposition.id_
+
+    new_deposition = await depositor.get_new_version(published_deposition)
+
+    updated_files = {
+        "to_update": b"I am up to date",
+    }
+    await depositor.delete_file(new_deposition, "to_delete")
+    await depositor.update_file(
+        new_deposition, "to_update", BytesIO(updated_files["to_update"])
+    )
+
+    latest_deposition = await depositor.get_deposition(conceptdoi)
+    assert latest_deposition.state == "unsubmitted"
+    assert latest_deposition.id_ == new_deposition.id_
+
+    # verify that the first version has the files we expect
+    v2_files = latest_deposition.files
+    assert len(v2_files) == 1
+
+    for deposition_file in v2_files:
+        download_link = deposition_file.links.download
+        expected_contents = updated_files[deposition_file.filename]
+
+        remote_contents = requests.get(
+            download_link, headers={"Authorization": f"bearer {upload_key}"}
+        )
+        assert expected_contents == remote_contents.text.encode("utf-8")
+
+    # TODO (daz): tried discarding but ran into an internal server error... revisit someday

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -155,7 +155,7 @@ async def test_full_zenodo_flow(depositor, deposition_metadata, upload_key):
     assert latest_deposition.state == "unsubmitted"
     assert latest_deposition.id_ == new_deposition.id_
 
-    # verify that the first version has the files we expect
+    # verify that the second version has the files we expect
     v2_files = latest_deposition.files
     assert len(v2_files) == 1
 
@@ -167,5 +167,3 @@ async def test_full_zenodo_flow(depositor, deposition_metadata, upload_key):
             download_link, headers={"Authorization": f"bearer {upload_key}"}
         )
         assert expected_contents == remote_contents.text.encode("utf-8")
-
-    # TODO (daz): tried discarding but ran into an internal server error... revisit someday

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -86,3 +86,20 @@ async def test_create_deposition(depositor, deposition_metadata):
 
     assert clean_metadata(deposition.metadata) == clean_metadata(deposition_metadata)
     assert deposition.state == "unsubmitted"
+
+
+@pytest.mark.asyncio
+async def test_get_deposition(depositor, deposition_metadata):
+    pass
+    # commented these out so I can commit.
+    # deposition = await depositor.create_deposition(deposition_metadata)
+    # TODO (daz): guess we need to add files and publish, before it gets a concept
+    # depositor.create_file()
+    # depositor.publish()
+    # we should probably make just one deposition and do a bunch of stuff to it.
+    # this means we also need to implement get by specific doi.
+
+    # concept_doi = deposition.conceptdoi
+    # assert concept_doi is not None, "has a concept_doi"
+    # latest_deposition = await depositor.get_deposition(concept_doi)
+    # assert latest_deposition._id == deposition._id


### PR DESCRIPTION
This is very much cut-and-paste from the `ZenodoDepositionInterface`, and the code isn't used anywhere outside of the test I just wrote.

I decided to make One Big Test because I didn't want to make a million little depositions on the sandbox environment.

There are a couple logic changes which I'll point out in the actual PR comments.

@zschira - let me know if you'd like to walk through these changes together, +504 is pretty big. Though, again, I think most of this will be pretty familiar to you.