### PR TITLE
Apply changes to new deposition before datapackage update

### DIFF
--- a/src/pudl_archiver/zenodo/api_client.py
+++ b/src/pudl_archiver/zenodo/api_client.py
@@ -122,6 +122,7 @@ class ZenodoDepositionInterface:
         # upload takes (source: IOBase | Path, dest: str) tuples; delete just takes the str key to delete.
         self.uploads: list[_UploadSpec] = []
         self.deletes: list[str] = []
+        self.changed = False
 
     @classmethod
     async def open_interface(

--- a/src/pudl_archiver/zenodo/api_client.py
+++ b/src/pudl_archiver/zenodo/api_client.py
@@ -388,10 +388,8 @@ class ZenodoDepositionInterface:
             file: DepositionFile metadata pertaining to file to be deleted.
         """
         logger.info(f"DELETE file {file.filename} from {file.links.self}")
-        await self._check_resp(
-            await self.session.delete(
-                file.links.self, params={"access_token": self.upload_key}
-            )
+        await self.session.delete(
+            file.links.self, params={"access_token": self.upload_key}
         )
 
     async def upload(self, file: BinaryIO, filename: str):


### PR DESCRIPTION
As discussed in #32 we need to apply changes to the deposition before refreshing the `datapackage.json` - this lets us have an up-to-date view of what's in the deposition, what the remote URLs are, etc.