### PR TITLE
Remove Zenodo from the ZenodoDepositionInterface

### DIFF
--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -156,13 +156,21 @@ class ZenodoDepositor:
             )
 
         latest_deposition = Deposition(**sorted(response, key=lambda d: d["id"])[-1])
-        full_deposition_json = await self.request(
+        return await self.get_record(latest_deposition.id_)
+
+    async def get_record(self, rec_id: int) -> Deposition:
+        """Get a deposition by its record ID directly instead of through concept.
+
+        Args:
+            rec_id: The record ID of the deposition you would like to get.
+        """
+        response = await self.request(
             "GET",
-            f"{url}/{latest_deposition.id_}",
-            log_label=f"Get freshest data for {latest_deposition.id_}",
+            f"{self.api_root}/deposit/depositions/{rec_id}",
+            log_label=f"Get deposition for {rec_id}",
             headers=self.auth_write,
         )
-        return Deposition(**full_deposition_json)
+        return Deposition(**response)
 
     async def get_new_version(self, deposition: Deposition) -> Deposition:
         """Get a new version of a deposition.

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -1,4 +1,5 @@
 """Core routines for frictionless data package construction."""
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 
@@ -78,7 +79,10 @@ class DataPackage(BaseModel):
 
     @classmethod
     def from_filelist(
-        cls, name: str, files: list[DepositionFile], resources: dict[str, ResourceInfo]
+        cls,
+        name: str,
+        files: Iterable[DepositionFile],
+        resources: dict[str, ResourceInfo],
     ) -> "DataPackage":
         """Create a frictionless datapackage from a list of files and partitions.
 

--- a/src/pudl_archiver/zenodo/api_client.py
+++ b/src/pudl_archiver/zenodo/api_client.py
@@ -23,30 +23,6 @@ from pudl_archiver.zenodo.entities import (
 logger = logging.getLogger(f"catalystcoop.{__name__}")
 
 
-class ZenodoClientException(Exception):
-    """Captures the JSON error information from Zenodo."""
-
-    def __init__(self, kwargs):
-        """Constructor.
-
-        Args:
-            kwargs: dictionary with "response" mapping to the actual
-                aiohttp.ClientResponse and "json" mapping to the JSON content.
-        """
-        self.kwargs = kwargs
-        self.status = kwargs["response"].status
-        self.message = kwargs["json"].get("message", {})
-        self.errors = kwargs["json"].get("errors", {})
-
-    def __str__(self):
-        """The JSON has all we really care about."""
-        return f"ZenodoClientException({self.kwargs['json']})"
-
-    def __repr__(self):
-        """But the kwargs are useful for recreating this object."""
-        return f"ZenodoClientException({repr(self.kwargs)})"
-
-
 class _UploadSpec(BaseModel):
     """Defines an upload that will be done by ZenodoDepositionInterface."""
 
@@ -173,17 +149,6 @@ class ZenodoDepositionInterface:
         )
 
         return interface
-
-    async def _check_resp(self, response, **kwargs):
-        """Checks Zenodo responses for extra error information.
-
-        It's hard to pass this back into the aiohttp.ClientResponseError so
-        we do this instead.
-        """
-        resp_json = await response.json(**kwargs)
-        if response.status >= 400:
-            raise ZenodoClientException({"response": response, "json": resp_json})
-        return resp_json
 
     async def remote_fileinfo(self, deposition: Deposition):
         """Return info on all files contained in deposition.

--- a/src/pudl_archiver/zenodo/api_client.py
+++ b/src/pudl_archiver/zenodo/api_client.py
@@ -194,14 +194,7 @@ class ZenodoDepositionInterface:
         Returns:
             Dictionary mapping filenames to DepositionFile metadata objects.
         """
-        url = deposition.links.files
-        params = {"access_token": self.upload_key}
-
-        logger.info(f"GET {url}")
-        async with self.session.get(url, params=params) as response:
-            raw_json = await self._check_resp(response)
-
-        return {file["filename"]: DepositionFile(**file) for file in raw_json}
+        return {f.filename: f for f in deposition.files}
 
     async def create_deposition(self, data_source_id: str) -> Deposition:
         """Create a Zenodo deposition resource.

--- a/src/pudl_archiver/zenodo/api_client.py
+++ b/src/pudl_archiver/zenodo/api_client.py
@@ -389,8 +389,10 @@ class ZenodoDepositionInterface:
             file: DepositionFile metadata pertaining to file to be deleted.
         """
         logger.info(f"DELETE file {file.filename} from {file.links.self}")
-        await self.session.delete(
-            file.links.self, params={"access_token": self.upload_key}
+        await self._check_resp(
+            await self.session.delete(
+                file.links.self, params={"access_token": self.upload_key}
+            )
         )
 
     async def upload(self, file: BinaryIO, filename: str):

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -5,12 +5,22 @@ See https://developers.zenodo.org/#entities for more info.
 import datetime
 from typing import Literal
 
-from pydantic import AnyHttpUrl, BaseModel, Field, constr, validator
+from pydantic import AnyHttpUrl, BaseModel, ConstrainedStr, Field, validator
 
 from pudl.metadata.classes import Contributor, DataSource
 
-Doi = constr(regex=r"10\.5281/zenodo\.\d{6,7}")
-SandboxDoi = constr(regex=r"10\.5072/zenodo\.\d{6,7}")
+
+class Doi(ConstrainedStr):
+    """The DOI format for production Zenodo."""
+
+    regex = r"10\.5281/zenodo\.\d{6,7}"
+
+
+class SandboxDoi(ConstrainedStr):
+    """The DOI format for sandbox Zenodo."""
+
+    regex = r"10\.5072/zenodo\.\d{6,7}"
+
 
 PUDL_DESCRIPTION = """
 <p>This archive contains raw input data for the Public Utility Data Liberation (PUDL)

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -142,6 +142,11 @@ async def test_full_zenodo_flow(depositor, deposition_metadata, upload_key):
     assert latest_deposition.id_ == published_deposition.id_
 
     new_deposition = await depositor.get_new_version(published_deposition)
+    doubly_new_deposition = await depositor.get_new_version(new_deposition)
+
+    # if we call get_new_version on an unsubmitted deposition, we should just get
+    # that one back.
+    assert new_deposition.id_ == doubly_new_deposition.id_
 
     updated_files = {
         "to_update": b"I am up to date",

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -70,7 +70,7 @@ def publish_key(dotenv):
 @pytest_asyncio.fixture()
 async def session():
     """Create async http session."""
-    async with aiohttp.ClientSession(raise_for_status=True) as session:
+    async with aiohttp.ClientSession(raise_for_status=False) as session:
         yield session
 
 


### PR DESCRIPTION
This removes all direct Zenodo access from `api_client.py` - which means we should probably reorganize the code now that the code in the `zenodo` directory doesn't directly deal with Zenodo anymore.

There's still plenty of clean-up to do with, e.g., collapsing `ZenodoClient` and `ZenodoDepositionInterface` into one `DepositionTwiddler` class or something better-named - but I think that's the next step here.