### PR TITLE
ZenodoDepositionInterface / ZenodoClient Unification

### DIFF
--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -31,8 +31,6 @@ async def archive_dataset(
     name: str,
     zenodo_deposition_interface: ZenodoDepositionInterface,
     session: aiohttp.ClientSession,
-    initialize: bool = False,
-    dry_run: bool = True,
 ):
     """Download and archive dataset on zenodo."""
     cls = ARCHIVERS.get(name)
@@ -65,17 +63,15 @@ async def archive_datasets(
         # List to gather all archivers to run asyncronously
         tasks = []
         for dataset in datasets:
-            zenodo_deposition_interface = (
-                await ZenodoDepositionInterface.open_interface(
-                    dataset,
-                    session,
-                    upload_key,
-                    publish_key,
-                    deposition_settings=pathlib.Path("dataset_doi.yaml"),
-                    create_new=initialize,
-                    dry_run=dry_run,
-                    sandbox=sandbox,
-                )
+            zenodo_deposition_interface = await ZenodoDepositionInterface.create(
+                dataset,
+                session,
+                upload_key,
+                publish_key,
+                deposition_settings=pathlib.Path("dataset_doi.yaml"),
+                create_new=initialize,
+                dry_run=dry_run,
+                sandbox=sandbox,
             )
 
             tasks.append(
@@ -83,8 +79,6 @@ async def archive_datasets(
                     dataset,
                     zenodo_deposition_interface,
                     session,
-                    initialize=initialize,
-                    dry_run=dry_run,
                 )
             )
 

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -50,21 +50,15 @@ class _HyperlinkExtractor(HTMLParser):
 class AbstractDatasetArchiver(ABC):
     """An abstract base archiver class."""
 
-    from pudl_archiver.zenodo.api_client import ZenodoDepositionInterface
-
     name: str
 
-    def __init__(
-        self, session: aiohttp.ClientSession, deposition: ZenodoDepositionInterface
-    ):
+    def __init__(self, session: aiohttp.ClientSession):
         """Initialize Archiver object.
 
         Args:
             session: Async HTTP client session manager.
-            deposition: Interface to Zenodo deposition relevant to data source.
         """
         self.session = session
-        self.deposition = deposition
 
         # Create a temporary directory for downloading data
         self._download_directory_manager = tempfile.TemporaryDirectory()
@@ -157,14 +151,13 @@ class AbstractDatasetArchiver(ABC):
                 f"Make sure your filter_pattern is correct or if the structure of the {url} page changed."
             )
 
-        return list(hyperlinks)[:1]
+        return hyperlinks
 
-    async def create_archive(self):
-        """Download all resources and create an archive for upload.
+    async def download_all_resources(self) -> dict[str, ResourceInfo]:
+        """Download all resources.
 
         This method uses the awaitables returned by `get_resources`. It
-        coordinates downloading all resources concurrently, then creating a
-        new zenodo deposition version containing those resources.
+        coordinates downloading all resources concurrently.
         """
         # Get all awaitables from get_resources
         resources = [resource async for resource in self.get_resources()]
@@ -176,5 +169,4 @@ class AbstractDatasetArchiver(ABC):
             self.logger.info(f"Downloaded {resource_info.local_path}.")
             resource_dict[str(resource_info.local_path.name)] = resource_info
 
-        # Add to zenodo deposition
-        await self.deposition.add_files(resource_dict)
+        return resource_dict

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -157,7 +157,7 @@ class AbstractDatasetArchiver(ABC):
                 f"Make sure your filter_pattern is correct or if the structure of the {url} page changed."
             )
 
-        return hyperlinks
+        return list(hyperlinks)[:1]
 
     async def create_archive(self):
         """Download all resources and create an archive for upload.

--- a/src/pudl_archiver/zenodo/api_client.py
+++ b/src/pudl_archiver/zenodo/api_client.py
@@ -66,9 +66,6 @@ class ZenodoDepositionInterface:
     ):
         """Prepare the ZenodoStorage interface.
 
-        Do not call this directly, use .create(). There's async stuff that needs to happen
-        for initialization.
-
         Args:
             data_source_id: Data source ID.
             session: Async http client session manager.

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -171,7 +171,7 @@ async def test_zenodo_workflow(
 
     # Create new deposition and add files
 
-    interface = await ZenodoDepositionInterface.open_interface(
+    interface = await ZenodoDepositionInterface.create(
         **(deposition_interface_args | {"create_new": True})
     )
     resources = {
@@ -184,9 +184,7 @@ async def test_zenodo_workflow(
 
     # Wait before trying to access newly created deposition
     time.sleep(1.0)
-    interface = await ZenodoDepositionInterface.open_interface(
-        **deposition_interface_args
-    )
+    interface = await ZenodoDepositionInterface.create(**deposition_interface_args)
     # Get files from first version of deposition
     for file_data in test_files["original"]:
         # Verify that all expected files are in deposition
@@ -210,9 +208,7 @@ async def test_zenodo_workflow(
 
     # Wait before trying to access newly created deposition
     time.sleep(1.0)
-    interface = await ZenodoDepositionInterface.open_interface(
-        **(deposition_interface_args | {"create_new": True})
-    )
+    interface = await ZenodoDepositionInterface.create(**deposition_interface_args)
     # Get files from updated version of deposition
     for file_data in test_files["updated"]:
         assert file_data["path"].name in interface.deposition_files

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -82,7 +82,7 @@ async def test_download_zipfile(mocker, bad_zipfile, good_zipfile):
     )
 
     # Initialize MockArchiver class
-    archiver = MockArchiver(None, None)
+    archiver = MockArchiver(None)
 
     url = "www.fake.url.com"
     with pytest.raises(
@@ -109,7 +109,7 @@ async def test_download_file(mocker, file_data):
     actually download any files.
     """
     # Initialize MockArchiver class
-    archiver = MockArchiver(None, None)
+    archiver = MockArchiver(None)
 
     session_mock = mocker.MagicMock(name="session_mock")
     archiver.session = session_mock
@@ -168,7 +168,7 @@ async def test_get_hyperlinks(docname, pattern, links, request, html_docs):
     html = html_docs[docname]
 
     # Initialize MockArchiver class
-    archiver = MockArchiver(None, None)
+    archiver = MockArchiver(None)
 
     mocker = request.getfixturevalue("mocker")
 


### PR DESCRIPTION
This puts the various initialization/cleanup code that was in `ZenodoClient` into `ZenodoDepositionInterface` and simplifies the calling process by putting the high-level business logic in `ZenodoDepositionInterface.run`.