### PR TITLE
Rename now misleadingly-named ZenodoDepositionInterface

### DIFF
--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -5,8 +5,9 @@ import pathlib
 
 import aiohttp
 
+import pudl_archiver.orchestrator  # noqa: 401
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver
-from pudl_archiver.zenodo.api_client import ZenodoDepositionInterface
+from pudl_archiver.orchestrator import DepositionOrchestrator
 
 
 def all_archivers():
@@ -53,7 +54,7 @@ async def archive_datasets(
                 raise RuntimeError(f"Dataset {dataset} not supported")
             else:
                 downloader = cls(session)
-            zenodo_deposition_interface = ZenodoDepositionInterface(
+            orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,
                 session,
@@ -65,7 +66,7 @@ async def archive_datasets(
                 sandbox=sandbox,
             )
 
-            tasks.append(zenodo_deposition_interface.run())
+            tasks.append(orchestrator.run())
 
         results = zip(datasets, await asyncio.gather(*tasks, return_exceptions=True))
         exceptions = [

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -1,4 +1,4 @@
-"""Core routines for archiving raw data packages on Zenodo."""
+"""Core routines for archiving raw data packages."""
 import io
 import logging
 from hashlib import md5
@@ -49,8 +49,8 @@ def _compute_md5(file_path: Path) -> str:
     return hash_md5.hexdigest()
 
 
-class ZenodoDepositionInterface:
-    """Interface to a single Zenodo Deposition."""
+class DepositionOrchestrator:
+    """Interface to a single Deposition."""
 
     def __init__(
         self,
@@ -73,7 +73,7 @@ class ZenodoDepositionInterface:
             publish_key: Zenodo API publish key.
 
         Returns:
-            ZenodoDepositionInterface
+            DepositionOrchestrator
         """
         if sandbox:
             self.api_root = "https://sandbox.zenodo.org/api"
@@ -83,6 +83,7 @@ class ZenodoDepositionInterface:
         self.sandbox = sandbox
         self.data_source_id = data_source_id
 
+        # TODO (daz): pass in the depositor separately too - no reason to couple this class to Zenodo
         self.session = session
 
         self.upload_key = upload_key
@@ -94,6 +95,7 @@ class ZenodoDepositionInterface:
         # Map resource name to resource partitions
         self.resource_parts: dict[str, dict] = {}
 
+        # TODO (daz): don't hold references to the depositions at the instance level.
         self.deposition: Deposition | None = None
         self.new_deposition: Deposition | None = None
         self.deposition_files: dict[str, DepositionFile] = {}
@@ -134,6 +136,7 @@ class ZenodoDepositionInterface:
         # Map file name to file metadata for all files in deposition
         self.deposition_files = await self._remote_fileinfo(self.new_deposition)
 
+    # TODO (daz): inline this.
     async def _remote_fileinfo(self, deposition: Deposition):
         """Return info on all files contained in deposition.
 
@@ -145,6 +148,7 @@ class ZenodoDepositionInterface:
         """
         return {f.filename: f for f in deposition.files}
 
+    # TODO (daz): inline this.
     async def _create_deposition(self, data_source_id: str) -> Deposition:
         """Create a Zenodo deposition resource.
 

--- a/tests/unit/zenodo_api_test.py
+++ b/tests/unit/zenodo_api_test.py
@@ -2,7 +2,7 @@
 import pydantic
 import pytest
 
-from pudl_archiver.zenodo.api_client import DatasetSettings
+from pudl_archiver.orchestrator import DatasetSettings
 
 
 def test_dataset_settings():


### PR DESCRIPTION
It is the deposition orchestrator now so let's call it that.

I split this out because I was worried doing the rename in the same PR would cause mayhem in the diff view.

Also threw a bunch of TODOs in here to keep notes for the next time we jump into this - I think it's about time to focus on the Dagster stuff.