### PR TITLE
FERC EQR Archiver

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -29,6 +29,7 @@ jobs:
           - ferc6
           - ferc60
           - ferc714
+          - ferceqr
           - mshamines
           - phmsagas
 

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -260,13 +260,13 @@ class AbstractDatasetArchiver(ABC):
 
         # Download resources concurrently and prepare metadata
         for resource_chunk in resource_chunks:
+            for resource_coroutine in asyncio.as_completed(resource_chunk):
+                resource_info = await resource_coroutine
+                self.logger.info(f"Downloaded {resource_info.local_path}.")
+                yield str(resource_info.local_path.name), resource_info
+
             # If requested, create a new temporary directory per resource chunk
             if self.directory_per_resource_chunk:
                 tmp_dir = tempfile.TemporaryDirectory()
                 self.download_directory = Path(tmp_dir.name)
                 self.logger.info(f"New download directory {self.download_directory}")
-
-            for resource_coroutine in asyncio.as_completed(resource_chunk):
-                resource_info = await resource_coroutine
-                self.logger.info(f"Downloaded {resource_info.local_path}.")
-                yield str(resource_info.local_path.name), resource_info

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -186,12 +186,18 @@ class AbstractDatasetArchiver(ABC):
             for i in range(math.ceil(len(resources) / chunksize))
         ]
 
+        if self.concurrency_limit:
+            self.logger.info("Downloading resources in chunks to limit concurrency")
+            self.logger.info(f"Resource chunks: {len(resource_chunks)}")
+            self.logger.info(f"Resources per chunk: {chunksize}")
+
         # Download resources concurrently and prepare metadata
         for resource_chunk in resource_chunks:
             # If requested, create a new temporary directory per resource chunk
             if self.directory_per_resource_chunk:
                 tmp_dir = tempfile.TemporaryDirectory()
                 self.download_directory = Path(tmp_dir.name)
+                self.logger.info(f"New download directory {self.download_directory}")
 
             for resource_coroutine in asyncio.as_completed(resource_chunk):
                 resource_info = await resource_coroutine

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -55,6 +55,7 @@ class AbstractDatasetArchiver(ABC):
 
     name: str
     concurrency_limit: int | None = None
+    directory_per_resource_chunk: bool = False
 
     def __init__(self, session: aiohttp.ClientSession):
         """Initialize Archiver object.
@@ -187,6 +188,11 @@ class AbstractDatasetArchiver(ABC):
 
         # Download resources concurrently and prepare metadata
         for resource_chunk in resource_chunks:
+            # If requested, create a new temporary directory per resource chunk
+            if self.directory_per_resource_chunk:
+                tmp_dir = tempfile.TemporaryDirectory()
+                self.download_directory = Path(tmp_dir.name)
+
             for resource_coroutine in asyncio.as_completed(resource_chunk):
                 resource_info = await resource_coroutine
                 self.logger.info(f"Downloaded {resource_info.local_path}.")

--- a/src/pudl_archiver/archivers/ferc/ferceqr.py
+++ b/src/pudl_archiver/archivers/ferc/ferceqr.py
@@ -14,6 +14,7 @@ class FercEQRArchiver(AbstractDatasetArchiver):
     """FERC EQR archiver."""
 
     name = "ferceqr"
+    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC EQR resources."""

--- a/src/pudl_archiver/archivers/ferc/ferceqr.py
+++ b/src/pudl_archiver/archivers/ferc/ferceqr.py
@@ -1,6 +1,4 @@
 """Download FERC EQR data."""
-import re
-import typing
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (
@@ -19,7 +17,6 @@ class FercEQRArchiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC EQR resources."""
-
         # Get non-transaction data (pre-2013)
         yield self.get_bulk_csv()
 
@@ -47,7 +44,11 @@ class FercEQRArchiver(AbstractDatasetArchiver):
         year: int,
         quarter: int | None = None,
     ) -> tuple[Path, dict]:
+        """Download FERC EQR transaction data (quarterly or annual).
 
+        Download a year (2002-2013) of FERC EQR transaction data,
+        or a quarter of 2014-present data.
+        """
         # For 2014 - present data
         if quarter is not None:
             part = None

--- a/src/pudl_archiver/archivers/ferc/ferceqr.py
+++ b/src/pudl_archiver/archivers/ferc/ferceqr.py
@@ -1,0 +1,74 @@
+"""Download FERC EQR data."""
+import re
+import typing
+from pathlib import Path
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+BASE_URL = "https://eqrreportviewer.ferc.gov/"
+
+
+class FercEQRArchiver(AbstractDatasetArchiver):
+    """FERC EQR archiver."""
+
+    name = "ferceqr"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download FERC EQR resources."""
+
+        # Get non-transaction data (pre-2013)
+        yield self.get_bulk_csv()
+
+        # Get 2002-2012 annual transaction data
+        for year in range(2002, 2012):
+            yield self.get_year_dbf(year)
+
+        # Get quarterly EQR data
+        link_pattern = re.compile(r"CSV_(\d{4})_Q([1-4]).zip")
+        for link in await self.get_hyperlinks(BASE_URL, link_pattern):
+            yield self.get_quarter_resource(link, link_pattern.search(link))
+
+    async def get_bulk_csv(self) -> tuple[Path, dict]:
+        """Download all 2002-2013 non-transaction data."""
+        url = "https://eqrdds.ferc.gov/eqrdbdownloads/eqr_nontransaction.zip"
+        download_path = self.download_directory / "ferceqr_nontrans.zip"
+        await self.download_zipfile(url, download_path)
+
+        return ResourceInfo(
+            local_path=download_path, partitions={"data_type": "non-transaction"}
+        )
+
+    async def get_year_dbf(
+        self, year: int, part: str | None = None
+    ) -> tuple[Path, dict]:
+        """Download a single year of FERC EQR data (2002-2012)."""
+        assert year >= 2012 and year <= 2002
+        part = "transaction"
+        url = "https://eqrdds.ferc.gov/eqrdbdownloads/eqr_transaction_{year}.zip"
+        download_path = self.download_directory / f"ferceqr-{year}--{part}.zip"
+
+        await self.download_zipfile(url, download_path)
+
+        return ResourceInfo(
+            local_path=download_path,
+            partitions={"year": year, "data_type": "transaction"},
+        )
+
+    async def get_quarter_resource(
+        self, link: str, match: typing.Match
+    ) -> tuple[Path, dict]:
+        """Download zip file of quarterly FERC EQR data (2013-present)."""
+        print(link)
+        url = f"https://eqrreportviewer.ferc.gov/DownloadRepositoryProd/BulkNew/CSV/{link}"
+        year = match.group(1)
+        quarter = match.group(2)
+        download_path = self.download_directory / f"ferceqr-{year}-{quarter}.zip"
+        await self.download_zipfile(url, download_path)
+
+        return ResourceInfo(
+            local_path=download_path, partitions={"year": year, "quarter": quarter}
+        )

--- a/src/pudl_archiver/archivers/ferc/ferceqr.py
+++ b/src/pudl_archiver/archivers/ferc/ferceqr.py
@@ -1,8 +1,6 @@
 """Download FERC EQR data."""
 from pathlib import Path
 
-import requests
-
 from pudl_archiver.archivers.classes import (
     AbstractDatasetArchiver,
     ArchiveAwaitable,
@@ -49,10 +47,6 @@ class FercEQRArchiver(AbstractDatasetArchiver):
         """Download a year (2002-2013) of FERC EQR transaction data."""
         url = f"https://eqrdds.ferc.gov/eqrdbdownloads/eqr_transaction_{year}.zip"
         download_path = self.download_directory / f"ferceqr-{year}-trans.zip"
-
-        response = requests.head(url)
-        print(response.ok)
-        exit()
 
         await self.download_zipfile(url, download_path)
 

--- a/src/pudl_archiver/archivers/ferc/ferceqr.py
+++ b/src/pudl_archiver/archivers/ferc/ferceqr.py
@@ -1,5 +1,4 @@
 """Download FERC EQR data."""
-import asyncio
 import ftplib  # nosec: B402
 from pathlib import Path
 
@@ -16,12 +15,15 @@ class FercEQRArchiver(AbstractDatasetArchiver):
     """FERC EQR archiver."""
 
     name = "ferceqr"
-    concurrency_limit = 1
+    concurrency_limit = 5
+    directory_per_resource_chunk = True
     max_wait_time = 36000
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC EQR resources."""
         # Get non-transaction data (pre-2013)
+        # Skip all pre-2013 data until access to FTP server is figured out
+        """
         for i in range(self.max_wait_time):
             self.logger.info(
                 f"Waiting for EQR to be available, attempt: {i}/{self.max_wait_time}"
@@ -37,10 +39,13 @@ class FercEQRArchiver(AbstractDatasetArchiver):
         # Get 2002-2013 annual transaction data
         for year in range(2002, 2014):
             yield self.get_year_dbf(year, ftp)
+        """
 
         # Get quarterly EQR data
-        for year in range(2014, 2023):
+        for year in range(2013, 2023):
             for quarter in range(1, 5):
+                if quarter < 3:
+                    continue
                 yield self.get_quarter_dbf(year, quarter)
 
     async def get_bulk_csv(self, ftp: ftplib.FTP) -> tuple[Path, dict]:

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -349,7 +349,7 @@ class ZenodoDepositor:
                 log_label=f"Uploading {target} to bucket",
                 data=data,
                 headers=self.auth_write,
-                timeout=1800,
+                timeout=3600,
             )
         elif deposition.links.files and force_api != "bucket":
             url = f"{deposition.links.files}"

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -349,6 +349,7 @@ class ZenodoDepositor:
                 log_label=f"Uploading {target} to bucket",
                 data=data,
                 headers=self.auth_write,
+                timeout=1800,
             )
         elif deposition.links.files and force_api != "bucket":
             url = f"{deposition.links.files}"

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -267,7 +267,6 @@ class DepositionOrchestrator:
     def _get_files_to_delete(self, resources) -> list[str]:
         # Delete files not included in new deposition
         files_to_delete = []
-        logger.info(f"Depo files: {list(self.deposition_files.keys())}")
         for filename, file_info in self.deposition_files.items():
             if filename not in resources and filename != "datapackage.json":
                 logger.info(f"Deleting {filename} from deposition.")

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -215,7 +215,7 @@ class DepositionOrchestrator:
 
             if change:
                 changed = True
-                await self._apply_changes(change)
+                await self._apply_change(change)
 
         # Check for files that should no longer be in deposition
         files_to_delete = self._get_files_to_delete(resources)
@@ -226,7 +226,7 @@ class DepositionOrchestrator:
 
         # Delete files no longer in deposition
         [
-            await self._apply_changes(
+            await self._apply_change(
                 _DepositionChange(action_type=_DepositionAction.DELETE, name=name)
             )
             for name in files_to_delete
@@ -294,7 +294,7 @@ class DepositionOrchestrator:
 
         return files_to_delete
 
-    async def _apply_changes(self, change: _DepositionChange):
+    async def _apply_change(self, change: _DepositionChange):
         """Actually upload and delete what we listed in self.uploads/deletes."""
         if change.action_type in [_DepositionAction.DELETE, _DepositionAction.UPDATE]:
             file_info = self.deposition_files[change.name]
@@ -374,7 +374,7 @@ class DepositionOrchestrator:
             old_datapackage = DataPackage.parse_raw(response_bytes)
 
             # Stage old datapackge to be deleted
-            await self._apply_changes(
+            await self._apply_change(
                 _DepositionChange(
                     action_type=_DepositionAction.DELETE,
                     name="datapackage.json",
@@ -394,7 +394,7 @@ class DepositionOrchestrator:
             bytes(datapackage.json(by_alias=True), encoding="utf-8")
         )
 
-        await self._apply_changes(
+        await self._apply_change(
             _DepositionChange(
                 action_type=_DepositionAction.CREATE,
                 name="datapackage.json",

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -1,6 +1,7 @@
 """Core routines for archiving raw data packages."""
 import io
 import logging
+from enum import Enum, auto
 from hashlib import md5
 from pathlib import Path
 
@@ -20,6 +21,12 @@ from pudl_archiver.zenodo.entities import (
 )
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
+
+
+class _DepositionAction(Enum):
+    CREATE = (auto(),)
+    UPDATE = (auto(),)
+    DELETE = (auto(),)
 
 
 class _UploadSpec(BaseModel):
@@ -92,20 +99,12 @@ class DepositionOrchestrator:
         self.depositor = ZenodoDepositor(upload_key, publish_key, session, self.sandbox)
         self.downloader = downloader
 
-        # Map resource name to resource partitions
-        self.resource_parts: dict[str, dict] = {}
-
         # TODO (daz): don't hold references to the depositions at the instance level.
         self.deposition: Deposition | None = None
         self.new_deposition: Deposition | None = None
         self.deposition_files: dict[str, DepositionFile] = {}
 
         self.dry_run = dry_run
-        # We accumulate changes in a changeset, then apply - makes dry runs and testing easier.
-        # upload takes (source: IOBase | Path, dest: str) tuples; delete just takes the DepositionFile.
-        self.uploads: list[_UploadSpec] = []
-        self.deletes: list[DepositionFile] = []
-        self.changed = False
 
         self.create_new = create_new
         self.deposition_settings = deposition_settings
@@ -115,10 +114,7 @@ class DepositionOrchestrator:
                 for name, dois in yaml.safe_load(f).items()
             }
 
-        self.async_initialized = False
-
     async def _initialize(self):
-        self.async_initialized = True
         if self.create_new:
             doi = None
             self.deposition = await self._create_deposition(self.data_source_id)
@@ -182,83 +178,114 @@ class DepositionOrchestrator:
             field being 'done' and 'unsubmitted', respectively.
         """
         await self._initialize()
-        resources = await self.downloader.download_all_resources()
-        # TODO (daz): pass around changesets instead of persisting them on the instance, this
-        # makes the ordering/dependency more explicit
-        self._generate_changes(resources)
 
-        # Leave immediately after generating changes if dry_run
+        resources = {}
+        changed = False
+        async for name, resource in self.downloader.download_all_resources():
+            resources[name] = resource
+            action = self._generate_changes(name, resource)
+
+            # Leave immediately after generating changes if dry_run
+            if self.dry_run:
+                continue
+
+            if action:
+                changed = True
+                await self._apply_changes(action, name, resource)
+
+        # Check for files that should no longer be in deposition
+        files_to_delete = self._get_files_to_delete(resources)
+        changed = changed or len(files_to_delete) > 0
         if self.dry_run:
-            logger.info("Dry run, aborting")
-            return self.new_deposition
+            return None
 
-        await self._apply_changes()
+        # Delete files no longer in deposition
+        [
+            await self._apply_changes(_DepositionAction.DELETE, name)
+            for name in files_to_delete
+        ]
+
         self.new_deposition = await self.depositor.get_record(self.new_deposition.id_)
-        await self._update_datapackage(resources)
-        await self._apply_changes()
-
-        if self.changed:
+        if changed:
+            # If there are any changes detected update datapackage and publish
+            await self._update_datapackage(resources)
             published = await self.depositor.publish_deposition(self.new_deposition)
             if self.create_new:
                 self._update_dataset_settings(published)
             return published
         else:
+            logger.info("No changes detected.")
             await self.depositor.delete_deposition(self.new_deposition)
             return self.deposition
 
-    def _generate_changes(self, resources):
-        for name, resource in resources.items():
-            filepath = resource.local_path
-            if name not in self.deposition_files:
-                logger.info(f"Adding {name} to deposition.")
+    def _generate_changes(self, name: str, resource: ResourceInfo) -> _DepositionAction:
+        if name not in self.deposition_files:
+            logger.info(f"Adding {name} to deposition.")
 
-                self.uploads.append(_UploadSpec(source=filepath, dest=filepath.name))
-            else:
-                file_info = self.deposition_files[name]
+            return _DepositionAction.CREATE
+        else:
+            file_info = self.deposition_files[name]
 
-                # If file is not exact match for existing file, update with new file
-                if (
-                    not (local_md5 := _compute_md5(resource.local_path))
-                    == file_info.checksum
-                ):
-                    logger.info(
-                        f"Updating {name}: local hash {local_md5} vs. remote {file_info.checksum}"
-                    )
-                    self.deletes.append(file_info)
-                    self.uploads.append(
-                        _UploadSpec(source=filepath, dest=filepath.name)
-                    )
+            # If file is not exact match for existing file, update with new file
+            if (
+                not (local_md5 := _compute_md5(resource.local_path))
+                == file_info.checksum
+            ):
+                logger.info(
+                    f"Updating {name}: local hash {local_md5} vs. remote {file_info.checksum}"
+                )
+                return _DepositionAction.UPDATE
 
+        return None
+
+    def _get_files_to_delete(self, resources) -> list[str]:
         # Delete files not included in new deposition
+        files_to_delete = []
+        logger.info(f"Depo files: {list(self.deposition_files.keys())}")
         for filename, file_info in self.deposition_files.items():
             if filename not in resources and filename != "datapackage.json":
-                self.deletes.append(file_info)
+                logger.info(f"Deleting {filename} from deposition.")
+                files_to_delete.append(filename)
 
-        self.changed = len(self.uploads or self.deletes) > 0
-        if self.changed:
-            logger.info(f"To delete: {self.deletes}")
-            logger.info(f"To upload: {self.uploads}")
-        else:
-            logger.info("No changes detected.")
+        return files_to_delete
 
-    async def _apply_changes(self):
+    async def _apply_changes(
+        self, action: _DepositionAction, name: str, resource: ResourceInfo | None = None
+    ):
         """Actually upload and delete what we listed in self.uploads/deletes."""
-        logger.info(f"To delete: {self.deletes}")
-        logger.info(f"To upload: {self.uploads}")
-        for file_info in self.deletes:
-            await self.depositor.delete_file(self.new_deposition, file_info.filename)
-        self.deletes = []
-        for upload in self.uploads:
-            if isinstance(upload.source, io.IOBase):
-                await self.depositor.create_file(
-                    self.new_deposition, upload.dest, upload.source
+        match action:
+            case _DepositionAction.DELETE:
+                file_info = self.deposition_files[name]
+                await self.depositor.delete_file(
+                    self.new_deposition, file_info.filename
                 )
-            else:
-                with upload.source.open("rb") as f:
-                    await self.depositor.create_file(
-                        self.new_deposition, upload.dest, f
-                    )
-        self.uploads = []
+            case _DepositionAction.CREATE:
+                if resource is None:
+                    raise RuntimeError("Must pass a resource to be uploaded.")
+
+                await self._upload_file(
+                    _UploadSpec(source=resource.local_path, dest=name)
+                )
+            case _DepositionAction.UPDATE:
+                if resource is None:
+                    raise RuntimeError("Must pass a resource to be uploaded.")
+
+                file_info = self.deposition_files[name]
+                await self.depositor.delete_file(
+                    self.new_deposition, file_info.filename
+                )
+                await self._upload_file(
+                    _UploadSpec(source=resource.local_path, dest=name)
+                )
+
+    async def _upload_file(self, upload: _UploadSpec):
+        if isinstance(upload.source, io.IOBase):
+            await self.depositor.create_file(
+                self.new_deposition, upload.dest, upload.source
+            )
+        else:
+            with upload.source.open("rb") as f:
+                await self.depositor.create_file(self.new_deposition, upload.dest, f)
 
     def _update_dataset_settings(self, published_deposition):
         # Get new DOI and update settings
@@ -295,10 +322,6 @@ class DepositionOrchestrator:
         Returns:
             Updated Deposition.
         """
-        # If nothing has changed, don't add new datapackage
-        if not self.changed:
-            return None
-
         if self.new_deposition is None:
             return
 
@@ -306,7 +329,7 @@ class DepositionOrchestrator:
         files = {file.filename: file for file in self.new_deposition.files}
 
         if "datapackage.json" in files:
-            self.deletes.append(files["datapackage.json"])
+            await self._apply_changes(_DepositionAction.DELETE, "datapackage.json")
             files.pop("datapackage.json")
 
         datapackage = DataPackage.from_filelist(
@@ -317,6 +340,6 @@ class DepositionOrchestrator:
             bytes(datapackage.json(by_alias=True), encoding="utf-8")
         )
 
-        self.uploads.append(
+        await self._upload_file(
             _UploadSpec(source=datapackage_json, dest="datapackage.json")
         )

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -226,7 +226,6 @@ class DepositionOrchestrator:
         if changed:
             # If there are any changes detected update datapackage and publish
             new_datapackage, old_datapackage = await self._update_datapackage(resources)
-            await self._apply_changes()
 
             run_summary = self.downloader.generate_summary(
                 old_datapackage, new_datapackage, resources

--- a/src/pudl_archiver/utils.py
+++ b/src/pudl_archiver/utils.py
@@ -44,6 +44,6 @@ async def retry_async(
                 raise e
             retry_delay_s = retry_base_s * 2 ** (try_count - 1)
             logger.info(
-                f"Error while executing {coro} (try #{try_count}, retry in {retry_delay_s}s): {e}"
+                f"Error while executing {coro} (try #{try_count}, retry in {retry_delay_s}s): {type(e)} - {e}"
             )
             await asyncio.sleep(retry_delay_s)

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -9,7 +9,6 @@ from typing import Literal
 from pydantic import AnyHttpUrl, BaseModel, ConstrainedStr, Field, validator
 
 from pudl.metadata.classes import Contributor, DataSource
-from pudl.metadata.constants import CONTRIBUTORS
 
 
 class Doi(ConstrainedStr):
@@ -90,7 +89,9 @@ class DepositionMetadata(BaseModel):
 
         if not creators:
             creators = [
-                DepositionCreator.from_contributor(CONTRIBUTORS["catalyst-cooperative"])
+                DepositionCreator.from_contributor(
+                    Contributor.from_id("catalyst-cooperative")
+                )
             ]
 
         return cls(

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -90,9 +90,7 @@ class DepositionMetadata(BaseModel):
 
         if not creators:
             creators = [
-                DepositionCreator.from_contributor(
-                    Contributor.from_id("catalyst-cooperative")
-                )
+                DepositionCreator.from_contributor(CONTRIBUTORS["catalyst-cooperative"])
             ]
 
         return cls(

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -9,6 +9,7 @@ from typing import Literal
 from pydantic import AnyHttpUrl, BaseModel, ConstrainedStr, Field, validator
 
 from pudl.metadata.classes import Contributor, DataSource
+from pudl.metadata.constants import CONTRIBUTORS
 
 
 class Doi(ConstrainedStr):

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -11,7 +11,7 @@ from aiohttp import ClientSession
 
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver, ArchiveAwaitable
 from pudl_archiver.archivers.validate import ValidationTestResult
-from pudl_archiver.frictionless import Resource
+from pudl_archiver.frictionless import Resource, ResourceInfo
 
 
 @pytest.fixture()
@@ -83,12 +83,53 @@ def html_docs():
 
 
 @pytest.mark.asyncio
-async def test_dir_per_resource(mocker):
-    """Test AbstractDatasetArchiver can download 1 resource at a time in a tempdir.
+@pytest.mark.parametrize(
+    "concurrency_limit,directory_per_resource_chunk,download_paths",
+    [
+        (1, True, ["path0", "path1", "path2", "path3", "path4"]),
+        (1, False, ["path0", "path0", "path0", "path0", "path0"]),
+        (5, True, ["path0", "path0", "path0", "path0", "path0"]),
+        (2, True, ["path0", "path0", "path1", "path1", "path2"]),
+    ],
+)
+async def test_resource_chunks(
+    concurrency_limit, directory_per_resource_chunk, download_paths, mocker
+):
+    """AbstractDatasetArchiver should be able to download resources in chunks."""
 
-    FERC EQR does not work with concurrent downloads, and is too big to have entire
-    dataset on disk at one time. This tests that
-    """
+    class MockArchiver(AbstractDatasetArchiver):
+        name = "mock"
+
+        def __init__(self, concurrency_limit, directory_per_resource_chunk):
+            self.concurrency_limit = concurrency_limit
+            self.directory_per_resource_chunk = directory_per_resource_chunk
+            super().__init__(None)
+
+        async def get_resources(self):
+            for i, _ in enumerate(download_paths):
+                yield self.get_resource(i)
+
+        async def get_resource(self, i):
+            return ResourceInfo(local_path=Path(self.download_directory), partitions=i)
+
+    class TmpDir:
+        def __init__(self):
+            self.call_count = 0
+
+        def __call__(self):
+            self.call_count += 1
+            return Path(f"path{self.call_count-1}")
+
+    tmpdir_mock = mocker.Mock(side_effect=TmpDir())
+    mocker.patch(
+        "pudl_archiver.archivers.classes.tempfile.TemporaryDirectory",
+        new=tmpdir_mock,
+    )
+
+    # Initialize MockArchiver class
+    archiver = MockArchiver(concurrency_limit, directory_per_resource_chunk)
+    async for name, resource in archiver.download_all_resources():
+        assert download_paths[resource.partitions] == name
 
 
 @pytest.mark.asyncio

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -71,6 +71,15 @@ def html_docs():
 
 
 @pytest.mark.asyncio
+async def test_dir_per_resource(mocker):
+    """Test AbstractDatasetArchiver can download 1 resource at a time in a tempdir.
+
+    FERC EQR does not work with concurrent downloads, and is too big to have entire
+    dataset on disk at one time. This tests that
+    """
+
+
+@pytest.mark.asyncio
 async def test_download_zipfile(mocker, bad_zipfile, good_zipfile):
     """Test download zipfile.
 

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -112,15 +112,7 @@ async def test_resource_chunks(
         async def get_resource(self, i):
             return ResourceInfo(local_path=Path(self.download_directory), partitions=i)
 
-    class TmpDir:
-        def __init__(self):
-            self.call_count = 0
-
-        def __call__(self):
-            self.call_count += 1
-            return Path(f"path{self.call_count-1}")
-
-    tmpdir_mock = mocker.Mock(side_effect=TmpDir())
+    tmpdir_mock = mocker.Mock(side_effect=[Path(f"path{i}") for i in range(6)])
     mocker.patch(
         "pudl_archiver.archivers.classes.tempfile.TemporaryDirectory",
         new=tmpdir_mock,


### PR DESCRIPTION
This script archives FERC EQR data from two sources: [2002-2013](https://www.ferc.gov/download-database) and [2014-present](https://eqrreportviewer.ferc.gov/). Technically, the code _should_ work: it produces the expected URLs for each resource, and sends them to the `download_zipfile()` method. However, two issues will frustrate the easy use of this archiver and should be dealt with more creatively.

1. Exceptionally slow download times from FERC. As FERC notes on their website:
> Due to the large size of the database, only three users are allowed to download simultaneously at any time. Because downloading may take a long time, it will likely work best if scheduled during off-peak hours, such as Sundays or at night.
Indeed, running this script generally results in timeout errors. Because of the 3-download limitation, downloads may want to be done serially, rather than in parallel.

2. Files exceed size limitations for GitHub runner, [as noted by Zane](https://github.com/catalyst-cooperative/pudl-archiver/issues/31#issuecomment-1404205318).

This issue is blocked by #44 