### PR TITLE
Add EIA 176 archiver

### DIFF
--- a/src/pudl_archiver/archivers/eia176.py
+++ b/src/pudl_archiver/archivers/eia176.py
@@ -1,0 +1,27 @@
+"""Download EIA 176 data."""
+from pathlib import Path
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+
+class Eia176Archiver(AbstractDatasetArchiver):
+    """EIA 176 archiver."""
+
+    name = "eia176"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download bulk EIA 176 data."""
+        yield self.get_bulk_resource()
+
+    async def get_bulk_resource(self) -> tuple[Path, dict]:
+        """Download zip file."""
+        # Use archive link if year is not most recent year
+        url = "https://www.eia.gov/naturalgas/ngqs/all_ng_data.zip"
+        download_path = self.download_directory / "eia176.zip"
+        await self.download_zipfile(url, download_path)
+
+        return ResourceInfo(local_path=download_path, partitions={})


### PR DESCRIPTION
This archiver grabs all EIA 176 reports in [one .zip file](https://www.eia.gov/naturalgas/ngqs/all_ng_data.zip) and archives them in Zenodo. This PR is linked to a PR in the pudl repo, which adds EIA176 to `sources.py`. To test before this gets merged into pudl/dev, you'll need to update pyproject.toml to point to the eia176 branch of the pudl repo. An example sandbox output can be found [here](https://sandbox.zenodo.org/record/1155188).

This data is listed in our [Future Datasets documentation](https://catalystcoop-pudl.readthedocs.io/en/dev/data_sources/wip_future.html#phmsa-natural-gas-pipelines) and our [Sloan New Data Plan](https://docs.google.com/document/d/1q9J49sDbwFNsbfk31p_sU0dSKiyq5TiO/edit#heading=h.gjdgxs).