### PR TITLE
Create MSHA archiver

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 ---
-name: pudl-archiver
+name: pudl-saver
 channels:
   - conda-forge
   - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 ---
-name: pudl-saver
+name: pudl-cataloger
 channels:
   - conda-forge
   - defaults

--- a/src/pudl_archiver/archivers/msha.py
+++ b/src/pudl_archiver/archivers/msha.py
@@ -16,7 +16,7 @@ BASE_URL = "https://arlweb.msha.gov/OpenGovernmentData/DataSets"
 class MshaArchiver(AbstractDatasetArchiver):
     """MSHA archiver."""
 
-    name = "msha"
+    name = "mshamines"
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download MSHA resources."""
@@ -31,7 +31,7 @@ class MshaArchiver(AbstractDatasetArchiver):
         """Download zip file."""
         # Use archive link if year is not most recent year
         url = f"{BASE_URL}/{link}"
-        dataset = int(match.group(1))
+        dataset = match.group(1)
         download_path = self.download_directory / f"msha-{dataset}.zip"
         await self.download_zipfile(url, download_path)
 


### PR DESCRIPTION
Progress so far:
- The [Mine Data Retrieval System page](https://www.msha.gov/data-and-reports/mine-data-retrieval-system) is where I was initially accessing data but it turns out to actually download it from hyperlinks you need to go to [this page](https://arlweb.msha.gov/OpenGovernmentData/OGIMSHA.asp).
- I'm currently printing out all the hyperlinks that are found on the web page because it's made it easier to debug
- Running `pudl_archiver --datasets mshamines --initialize --sandbox` gives me a timeout error when uploading `Violations.zip`. I think this is because it's too large but I haven't really looked into this error at all so that's a guess. 

Left to do:

- [ ] Get the metadata definitions file for each dataset. This gives the type and description of each column. I think we probably do want to get these files. See below for more information about this
- [ ] Debug Timeout error when uploading `Violations.zip` file. I believe this is the largest file (265.7 MB when zipped and 1.29 GB when unzipped). 
- [ ] Take out logging statement in `pudl_archiver.archivers.msha` that prints out all the hyperlinks found on the web page. (used for debugging)
- [ ] There are a few more data exploration tools on the [Mine Data Retrieval System](https://www.msha.gov/data-and-reports/mine-data-retrieval-system) page under "Other MSHA Data Reports". I haven't really looked at these but maybe they're something we want to archive? It could be that it's just a data exploration tool for the `.zip` datasets that are already being archived in this PR. So maybe don't worry about these reports.

Definitions files:  
The definition file for each dataset comes in a separate `.txt` file. I think archiving these `.txt` files should be a different function in the same MSHA archiver module (or part of `get_resources`) but maybe I'm wrong there. 