### PR TITLE
Archive EIA Thermoelectric Cooling Water data

### DIFF
--- a/src/pudl_archiver/archivers/eiawater.py
+++ b/src/pudl_archiver/archivers/eiawater.py
@@ -1,0 +1,43 @@
+"""Download EIA Thermal Cooling Water data."""
+import logging
+import re
+import typing
+from pathlib import Path
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+logger = logging.getLogger(f"catalystcoop.{__name__}")
+BASE_URL = "https://www.eia.gov/electricity/data/water"
+
+
+class Eia923Archiver(AbstractDatasetArchiver):
+    """EIA Thermal Cooling Water archiver."""
+
+    name = "eiawater"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download EIA Thermal Cooling Water resources."""
+        link_pattern = re.compile(r"cooling_(summary|detail)_(\d{4})\.xlsx")
+
+        for link in await self.get_hyperlinks(BASE_URL, link_pattern):
+            yield self.get_year_resource(link, link_pattern.search(link))
+
+    async def get_year_resource(
+        self, link: str, match: typing.Match
+    ) -> tuple[Path, dict]:
+        """Download zip file."""
+        url = f"{BASE_URL}/{link}"
+
+        table = match.group(1)
+        year = match.group(2)
+
+        download_path = self.download_directory / f"eiawater-{year}-{table}.xlsx"
+        await self.download_file(url, download_path)
+
+        return ResourceInfo(
+            local_path=download_path, partitions={"year": year, "table_type": table}
+        )


### PR DESCRIPTION
This archiver grabs all [EIA Thermoelectric Cooling Water reports](https://www.eia.gov/electricity/data/water/) and archives them in Zenodo. EIA releases both detailed and summary tables. From what I can tell, the summary table just aggregates columns across generators/boilers, and doesn't include additional information. For now, I've partitioned data by year and table_type (detailed or summary), but we could also decide to just archive the detailed files.

An example sandbox output can be found [here](https://sandbox.zenodo.org/record/1158797).