### PR TITLE
Fix epacamd_eia datasource id

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -34,6 +34,6 @@ eia_bulk_elec:
 epacems:
   production_doi: 10.5281/zenodo.4127054
   sandbox_doi: 10.5072/zenodo.672962
-epacmd_eia:
+epacamd_eia:
   production_doi: 10.5281/zenodo.6633769
   sandbox_doi: 10.5072/zenodo.1072000

--- a/src/pudl_archiver/archivers/epacamd_eia.py
+++ b/src/pudl_archiver/archivers/epacamd_eia.py
@@ -11,7 +11,7 @@ from pudl_archiver.archivers.classes import (
 class EpaCamdEiaArchiver(AbstractDatasetArchiver):
     """EPA CAMD archiver."""
 
-    name = "epacmd_eia"
+    name = "epacamd_eia"
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EPA CAMD to EIA crosswalk resources."""


### PR DESCRIPTION
There was a typo in the epacamd_eia id that came up in #54. I mean to fix this in my last round of fixes, but apparently forgot.