### PR TITLE
Add retry logic to all session.gets in data download process

### DIFF
--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -3,6 +3,7 @@ import asyncio
 import io
 import logging
 import tempfile
+import time
 import typing
 import zipfile
 from abc import ABC, abstractmethod
@@ -100,7 +101,31 @@ class AbstractDatasetArchiver(ABC):
         # If it makes it here that means it couldn't download a valid zipfile
         raise RuntimeError(f"Failed to download valid zipfile from {url}")
 
-    async def download_file(self, url: str, file: Path | io.BytesIO, **kwargs):
+    async def _get_with_retries(
+        self, url, retry_count: int = 5, retry_base_s: int = 1, **kwargs
+    ):
+        for try_count in range(1, retry_count + 1):
+            # try count is 1 indexed for logging clarity
+            try:
+                self.logger.info(f"GET {url} (try #{try_count})")
+                response = await self.session.get(url, **kwargs)
+                break
+            except aiohttp.ClientError as e:
+                if try_count == retry_count:
+                    raise e
+                retry_delay_s = retry_base_s * 2**try_count
+                self.logger.info(
+                    f"ClientError while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
+                )
+                time.sleep(retry_delay_s)
+        return response
+
+    async def download_file(
+        self,
+        url: str,
+        file: Path | io.BytesIO,
+        **kwargs,
+    ):
         """Download a file using async session manager.
 
         Args:
@@ -108,12 +133,13 @@ class AbstractDatasetArchiver(ABC):
             file: Local path to write file to disk or bytes object to save file in memory.
             kwargs: Key word args to pass to request.
         """
-        async with self.session.get(url, **kwargs) as response:
-            if isinstance(file, Path):
-                with open(file, "wb") as f:
-                    f.write(await response.read())
-            elif isinstance(file, io.BytesIO):
-                file.write(await response.read())
+        response = await self._get_with_retries(url, **kwargs)
+
+        if isinstance(file, Path):
+            with open(file, "wb") as f:
+                f.write(await response.read())
+        elif isinstance(file, io.BytesIO):
+            file.write(await response.read())
 
     async def get_hyperlinks(
         self,
@@ -135,9 +161,9 @@ class AbstractDatasetArchiver(ABC):
         """
         # Parse web page to get all hyperlinks
         parser = _HyperlinkExtractor()
-        async with self.session.get(url, ssl=verify) as response:
-            text = await response.text()
-            parser.feed(text)
+        response = await self._get_with_retries(url, ssl=verify)
+        text = await response.text()
+        parser.feed(text)
 
         # Filter to those that match filter_pattern
         hyperlinks = parser.hyperlinks

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -3,7 +3,6 @@ import asyncio
 import io
 import logging
 import tempfile
-import time
 import typing
 import zipfile
 from abc import ABC, abstractmethod
@@ -102,7 +101,7 @@ class AbstractDatasetArchiver(ABC):
         raise RuntimeError(f"Failed to download valid zipfile from {url}")
 
     async def _get_with_retries(
-        self, url, retry_count: int = 5, retry_base_s: int = 1, **kwargs
+        self, url: str, retry_count: int = 5, retry_base_s: int = 1, **kwargs
     ):
         for try_count in range(1, retry_count + 1):
             # try count is 1 indexed for logging clarity
@@ -117,7 +116,7 @@ class AbstractDatasetArchiver(ABC):
                 self.logger.info(
                     f"ClientError while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
                 )
-                time.sleep(retry_delay_s)
+                await asyncio.sleep(retry_delay_s)
         return response
 
     async def download_file(

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -228,11 +228,11 @@ async def archive_taxonomy(
             continue
 
         # Download file
-        async with session.get(url) as response:
-            path = Path(url_parsed.path).relative_to("/")
+        response = await _get_with_retries(session, url)
+        path = Path(url_parsed.path).relative_to("/")
 
-            with archive.open(str(path), "w") as f:
-                f.write(await response.content.read())
+        with archive.open(str(path), "w") as f:
+            f.write(await response.content.read())
 
 
 async def archive_year(
@@ -273,14 +273,14 @@ async def archive_year(
 
             # Download filing
             try:
-                async with session.get(filing.download_url) as response:
-                    # Write to zipfile
-                    with archive.open(f"{filing.entry_id}.xbrl", "w") as f:
-                        f.write(await response.content.read())
+                response = await _get_with_retries(session, filing.download_url)
             except aiohttp.client_exceptions.ClientResponseError as e:
                 logger.warning(
                     f"Failed to download XBRL filing {filing.title} for form{form_number}-{year}: {e.message}"
                 )
+            # Write to zipfile
+            with archive.open(f"{filing.entry_id}.xbrl", "w") as f:
+                f.write(await response.content.read())
 
         # Save snapshot of RSS feed
         with archive.open("rssfeed", "w") as f:
@@ -290,3 +290,23 @@ async def archive_year(
     logger.info(f"Finished scraping ferc{form_number}-{year}.")
 
     return archive_path
+
+
+async def _get_with_retries(
+    session, url, retry_count: int = 5, retry_base_s: int = 1, **kwargs
+):
+    for try_count in range(1, retry_count + 1):
+        # try count is 1 indexed for logging clarity
+        try:
+            logger.info(f"GET {url} (try #{try_count})")
+            response = await session.get(url, **kwargs)
+            break
+        except aiohttp.ClientError as e:
+            if try_count == retry_count:
+                raise e
+            retry_delay_s = retry_base_s * 2**try_count
+            logger.info(
+                f"ClientError while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
+            )
+            time.sleep(retry_delay_s)
+    return response

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -293,7 +293,11 @@ async def archive_year(
 
 
 async def _get_with_retries(
-    session, url, retry_count: int = 5, retry_base_s: int = 1, **kwargs
+    session: aiohttp.ClientSession,
+    url: str,
+    retry_count: int = 5,
+    retry_base_s: int = 1,
+    **kwargs,
 ):
     for try_count in range(1, retry_count + 1):
         # try count is 1 indexed for logging clarity
@@ -308,5 +312,5 @@ async def _get_with_retries(
             logger.info(
                 f"ClientError while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
             )
-            time.sleep(retry_delay_s)
+            await asyncio.sleep(retry_delay_s)
     return response

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -193,8 +193,8 @@ async def test_retries(mocker):
     archiver = MockArchiver(None)
     session_mock = mocker.Mock(name="session_mock")
     archiver.session = session_mock
-    sleep_mock = mocker.Mock()
-    mocker.patch("time.sleep", sleep_mock)
+    sleep_mock = mocker.AsyncMock()
+    mocker.patch("asyncio.sleep", sleep_mock)
     session_mock.get = mocker.Mock(side_effect=ClientError("test error"))
 
     with pytest.raises(ClientError):

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
+from aiohttp import ClientError, ClientSession
 
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver, ArchiveAwaitable
 
@@ -111,11 +112,13 @@ async def test_download_file(mocker, file_data):
     # Initialize MockArchiver class
     archiver = MockArchiver(None)
 
-    session_mock = mocker.MagicMock(name="session_mock")
+    session_mock = mocker.AsyncMock(name="session_mock")
     archiver.session = session_mock
 
     # Set return value
-    session_mock.get.return_value.__aenter__.return_value.read.return_value = file_data
+    response_mock = mocker.AsyncMock()
+    response_mock.read = mocker.AsyncMock(return_value=file_data)
+    session_mock.get = mocker.AsyncMock(return_value=response_mock)
 
     # Prepare args
     url = "www.fake.url.com"
@@ -172,11 +175,31 @@ async def test_get_hyperlinks(docname, pattern, links, request, html_docs):
 
     mocker = request.getfixturevalue("mocker")
 
-    session_mock = mocker.MagicMock(name="session_mock")
+    session_mock = mocker.AsyncMock(name="session_mock", spec=ClientSession)
     archiver.session = session_mock
 
     # Set return value
-    session_mock.get.return_value.__aenter__.return_value.text.return_value = html
+    response_mock = mocker.AsyncMock()
+    response_mock.text = mocker.AsyncMock(return_value=html)
+    session_mock.get = mocker.AsyncMock(return_value=response_mock)
 
     found_links = await archiver.get_hyperlinks("fake_url", pattern)
     assert set(found_links) == set(links)
+
+
+@pytest.mark.asyncio
+async def test_retries(mocker):
+    # Initialize MockArchiver class
+    archiver = MockArchiver(None)
+    session_mock = mocker.Mock(name="session_mock")
+    archiver.session = session_mock
+    sleep_mock = mocker.Mock()
+    mocker.patch("time.sleep", sleep_mock)
+    session_mock.get = mocker.Mock(side_effect=ClientError("test error"))
+
+    with pytest.raises(ClientError):
+        await archiver.download_file("foo", io.BytesIO())
+
+    assert session_mock.get.call_count == 5
+    assert sleep_mock.call_count == 4
+    sleep_mock.assert_has_calls([mocker.call(x) for x in [2, 4, 8, 16]])

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -1,0 +1,19 @@
+import pytest
+from aiohttp import ClientError
+
+from pudl_archiver.archivers.ferc.xbrl import _get_with_retries
+
+
+@pytest.mark.asyncio
+async def test_retries(mocker):
+    session_mock = mocker.Mock(name="session_mock")
+    sleep_mock = mocker.Mock()
+    mocker.patch("time.sleep", sleep_mock)
+    session_mock.get = mocker.AsyncMock(side_effect=ClientError("test error"))
+
+    with pytest.raises(ClientError):
+        await _get_with_retries(session_mock, "foo")
+
+    assert session_mock.get.call_count == 5
+    assert sleep_mock.call_count == 4
+    sleep_mock.assert_has_calls([mocker.call(x) for x in [2, 4, 8, 16]])

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -7,8 +7,8 @@ from pudl_archiver.archivers.ferc.xbrl import _get_with_retries
 @pytest.mark.asyncio
 async def test_retries(mocker):
     session_mock = mocker.Mock(name="session_mock")
-    sleep_mock = mocker.Mock()
-    mocker.patch("time.sleep", sleep_mock)
+    sleep_mock = mocker.AsyncMock()
+    mocker.patch("asyncio.sleep", sleep_mock)
     session_mock.get = mocker.AsyncMock(side_effect=ClientError("test error"))
 
     with pytest.raises(ClientError):


### PR DESCRIPTION
Since the `xbrl` and the `AbstractDatasetArchiver` uses of session are slightly different, I made two different utility functions for retries. Figured that'd be a little better than using a relatively unpopular library like aiohttp-retry.

Not sure if 2 -> 4 -> 8 -> 16s is the right set of exponential backoff.