### PR TITLE
Retry on asyncio.TimeoutError also

### DIFF
--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -109,12 +109,14 @@ class AbstractDatasetArchiver(ABC):
                 self.logger.info(f"GET {url} (try #{try_count})")
                 response = await self.session.get(url, **kwargs)
                 break
-            except aiohttp.ClientError as e:
+            # aiohttp client can either throw ClientError or TimeoutError
+            # see https://github.com/aio-libs/aiohttp/issues/7122
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 if try_count == retry_count:
                     raise e
                 retry_delay_s = retry_base_s * 2**try_count
                 self.logger.info(
-                    f"ClientError while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
+                    f"Error while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
                 )
                 await asyncio.sleep(retry_delay_s)
         return response

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -305,12 +305,14 @@ async def _get_with_retries(
             logger.info(f"GET {url} (try #{try_count})")
             response = await session.get(url, **kwargs)
             break
-        except aiohttp.ClientError as e:
+        # aiohttp client can either throw ClientError or TimeoutError
+        # see https://github.com/aio-libs/aiohttp/issues/7122
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             if try_count == retry_count:
                 raise e
             retry_delay_s = retry_base_s * 2**try_count
             logger.info(
-                f"ClientError while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
+                f"Error while getting {url} (try #{try_count}, retry in {retry_delay_s}s): {e}"
             )
             await asyncio.sleep(retry_delay_s)
     return response

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -2,6 +2,7 @@
 import io
 import re
 import tempfile
+from asyncio import TimeoutError
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -195,7 +196,15 @@ async def test_retries(mocker):
     archiver.session = session_mock
     sleep_mock = mocker.AsyncMock()
     mocker.patch("asyncio.sleep", sleep_mock)
-    session_mock.get = mocker.Mock(side_effect=ClientError("test error"))
+    session_mock.get = mocker.Mock(
+        side_effect=[
+            ClientError("test error"),
+            TimeoutError("test error"),
+            ClientError("test error"),
+            ClientError("test error"),
+            ClientError("test error"),
+        ]
+    )
 
     with pytest.raises(ClientError):
         await archiver.download_file("foo", io.BytesIO())

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -1,3 +1,5 @@
+from asyncio import TimeoutError
+
 import pytest
 from aiohttp import ClientError
 
@@ -9,7 +11,15 @@ async def test_retries(mocker):
     session_mock = mocker.Mock(name="session_mock")
     sleep_mock = mocker.AsyncMock()
     mocker.patch("asyncio.sleep", sleep_mock)
-    session_mock.get = mocker.AsyncMock(side_effect=ClientError("test error"))
+    session_mock.get = mocker.AsyncMock(
+        side_effect=[
+            ClientError("test error"),
+            TimeoutError("test error"),
+            TimeoutError("test error"),
+            ClientError("test error"),
+            ClientError("test error"),
+        ]
+    )
 
     with pytest.raises(ClientError):
         await _get_with_retries(session_mock, "foo")


### PR DESCRIPTION
`aiohttp.ClientSession` throws subclasses of `aiohttp.ClientError` on connection issues, except for timeouts, where it throws `asyncio.TimeoutError`. We would like to retry in all cases.

We ran into this here: https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/4108306582/jobs/7088850155

And there's an open issue for this in `aiohttp` here: https://github.com/aio-libs/aiohttp/issues/7122