### PR TITLE
Fix `--dry-run` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ conda env create -f environment.yml
 conda activate pudl-cataloger
 ```
 
+## Setting up environment
+API tokens are required to interact with Zenodo. There is one set of tokens for accessing
+the sandbox server, and one for the production server. The archiver tool expects these tokens
+to be set in the following environment variables: `ZENODO_TOKEN_PUBLISH` and `ZENODO_TOKEN_UPLOAD`
+or `ZENODO_SANDBOX_TOKEN_PUBLISH` and `ZENODO_SANDBOX_TOKEN_UPLOAD` for the sandbox server.
+
 ## Usage
 
 A CLI is provided for creating and updating archives. The basic usage looks like:
@@ -123,6 +129,8 @@ pudl_archiver --datasets {new_dataset_name} --initialize
 ## Development
 
 We only have one development specific tool, which is the Zenodo Postman collection in `/devtools`.
+This tool is used for testing and prototyping Zenodo API calls, it is not needed to use the archiver
+tool itself.
 
 To use it:
 

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -233,6 +233,11 @@ class DepositionOrchestrator:
                 self.deletes.append(file_info)
 
         self.changed = len(self.uploads or self.deletes) > 0
+        if self.changed:
+            logger.info(f"To delete: {self.deletes}")
+            logger.info(f"To upload: {self.uploads}")
+        else:
+            logger.info("No changes detected.")
 
     async def _apply_changes(self):
         """Actually upload and delete what we listed in self.uploads/deletes."""

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -185,6 +185,12 @@ class DepositionOrchestrator:
         # TODO (daz): pass around changesets instead of persisting them on the instance, this
         # makes the ordering/dependency more explicit
         self._generate_changes(resources)
+
+        # Leave immediately after generating changes if dry_run
+        if self.dry_run:
+            logger.info("Dry run, aborting")
+            return self.new_deposition
+
         await self._apply_changes()
         self.new_deposition = await self.depositor.get_record(self.new_deposition.id_)
         await self._update_datapackage(resources)
@@ -232,9 +238,6 @@ class DepositionOrchestrator:
         """Actually upload and delete what we listed in self.uploads/deletes."""
         logger.info(f"To delete: {self.deletes}")
         logger.info(f"To upload: {self.uploads}")
-        if self.dry_run:
-            logger.info("Dry run, aborting.")
-            return
         for file_info in self.deletes:
             await self.depositor.delete_file(self.new_deposition, file_info.filename)
         self.deletes = []


### PR DESCRIPTION
This PR fixes the `--dry-run` CLI option, which was previously skipping applying changes to a draft deposition, but then trying to publish that unchanged deposition, which was causing failures.

Closes #62 