### PR TITLE
Standardize filenames and add production DOIs

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -14,23 +14,23 @@ jobs:
     strategy:
       matrix:
         dataset:
-          - censusdp1tract
-          - eia176
-          - eia860
-          - eia860m
-          - eia861
-          - eia923
-          - eia_bulk_elec
-          - eiawater
-          - epacamd_eia
-          - epacems
-          - ferc1
-          - ferc2
-          - ferc6
-          - ferc60
-          - ferc714
+          # - censusdp1tract
+          # - eia176
+          # - eia860
+          # - eia860m
+          # - eia861
+          # - eia923
+          # - eia_bulk_elec
+          # - eiawater
+          # - epacamd_eia
+          # - epacems
+          # - ferc1
+          # - ferc2
+          # - ferc6
+          # - ferc60
+          # - ferc714
           - mshamines
-          - phmsagas
+          # - phmsagas
 
       fail-fast: false
     runs-on: ubuntu-latest
@@ -64,6 +64,9 @@ jobs:
         env:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+          # They're in the repository secrets, but we're not ready yet...
+          # ZENODO_PRODUCTION_TOKEN_UPLOAD: ${{ secrets.ZENODO_PRODUCTION_TOKEN_UPLOAD }}
+          # ZENODO_PRODUCTION_TOKEN_PUBLISH: ${{ secrets.ZENODO_PRODUCTION_TOKEN_PUBLISH }}
         run: |
           conda run -n pudl-cataloger pudl_archiver --sandbox --datasets ${{ matrix.dataset }}
 

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -14,23 +14,23 @@ jobs:
     strategy:
       matrix:
         dataset:
-          # - censusdp1tract
-          # - eia176
-          # - eia860
-          # - eia860m
-          # - eia861
-          # - eia923
-          # - eia_bulk_elec
-          # - eiawater
-          # - epacamd_eia
-          # - epacems
-          # - ferc1
-          # - ferc2
-          # - ferc6
-          # - ferc60
-          # - ferc714
+          - censusdp1tract
+          - eia176
+          - eia860
+          - eia860m
+          - eia861
+          - eia923
+          - eia_bulk_elec
+          - eiawater
+          - epacamd_eia
+          - epacems
+          - ferc1
+          - ferc2
+          - ferc6
+          - ferc60
+          - ferc714
           - mshamines
-          # - phmsagas
+          - phmsagas
 
       fail-fast: false
     runs-on: ubuntu-latest
@@ -64,11 +64,11 @@ jobs:
         env:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
-          # They're in the repository secrets, but we're not ready yet...
-          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
-          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
+          # They're in the repository secrets, but we need more QA/QC checks
+          # ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
+          # ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         run: |
-          conda run -n pudl-cataloger pudl_archiver --initialize --datasets ${{ matrix.dataset }}
+          conda run -n pudl-cataloger pudl_archiver --sandbox --datasets ${{ matrix.dataset }}
 
   archive-notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -65,8 +65,8 @@ jobs:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
           # They're in the repository secrets, but we're not ready yet...
-          ZENODO_PRODUCTION_TOKEN_UPLOAD: ${{ secrets.ZENODO_PRODUCTION_TOKEN_UPLOAD }}
-          ZENODO_PRODUCTION_TOKEN_PUBLISH: ${{ secrets.ZENODO_PRODUCTION_TOKEN_PUBLISH }}
+          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
+          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         run: |
           conda run -n pudl-cataloger pudl_archiver --initialize --datasets ${{ matrix.dataset }}
 

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -65,10 +65,10 @@ jobs:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
           # They're in the repository secrets, but we're not ready yet...
-          # ZENODO_PRODUCTION_TOKEN_UPLOAD: ${{ secrets.ZENODO_PRODUCTION_TOKEN_UPLOAD }}
-          # ZENODO_PRODUCTION_TOKEN_PUBLISH: ${{ secrets.ZENODO_PRODUCTION_TOKEN_PUBLISH }}
+          ZENODO_PRODUCTION_TOKEN_UPLOAD: ${{ secrets.ZENODO_PRODUCTION_TOKEN_UPLOAD }}
+          ZENODO_PRODUCTION_TOKEN_PUBLISH: ${{ secrets.ZENODO_PRODUCTION_TOKEN_PUBLISH }}
         run: |
-          conda run -n pudl-cataloger pudl_archiver --sandbox --datasets ${{ matrix.dataset }}
+          conda run -n pudl-cataloger pudl_archiver --initialize --datasets ${{ matrix.dataset }}
 
   archive-notify:
     runs-on: ubuntu-latest

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -2,8 +2,8 @@ censusdp1tract:
   production_doi: 10.5281/zenodo.4127048
   sandbox_doi: 10.5072/zenodo.1151526
 eia176:
-  production_doi: null
-  sandbox_doi: 10.5072/zenodo.1155187
+  production_doi: 10.5281/zenodo.7682357
+  sandbox_doi: 10.5072/zenodo.1168394
 eia860:
   production_doi: 10.5281/zenodo.4127026
   sandbox_doi: 10.5072/zenodo.672209
@@ -20,7 +20,7 @@ eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366
   sandbox_doi: 10.5072/zenodo.1103571
 eiawater:
-  production_doi: null
+  production_doi: 10.5281/zenodo.7683135
   sandbox_doi: 10.5072/zenodo.1161347
 epacamd_eia:
   production_doi: 10.5281/zenodo.6633769
@@ -47,5 +47,5 @@ mshamines:
   production_doi: null
   sandbox_doi: 10.5072/zenodo.1158828
 phmsagas:
-  production_doi: null
+  production_doi: 10.5281/zenodo.7683351
   sandbox_doi: 10.5072/zenodo.1161321

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -44,7 +44,7 @@ ferc714:
   production_doi: 10.5281/zenodo.4127100
   sandbox_doi: 10.5072/zenodo.1114673
 mshamines:
-  production_doi: null
+  production_doi: 10.5281/zenodo.7683517
   sandbox_doi: 10.5072/zenodo.1158828
 phmsagas:
   production_doi: 10.5281/zenodo.7683351

--- a/src/pudl_archiver/archivers/mshamines.py
+++ b/src/pudl_archiver/archivers/mshamines.py
@@ -59,7 +59,7 @@ MSHA_DATASETS = {
     "violations_definitions": "https://arlweb.msha.gov/OpenGovernmentData/DataSets/violations_Definition_File.txt",
     "107a": "https://arlweb.msha.gov/OpenGovernmentData/107a/107aOrders.xlsx",
 }
-""" Dictionary of expected MSHA tables/definition files and pathways."""
+"""Dictionary of expected MSHA data and definition files, and corresponding URLs."""
 
 
 class MshaArchiver(AbstractDatasetArchiver):
@@ -113,15 +113,15 @@ class MshaArchiver(AbstractDatasetArchiver):
         dataset = filename.replace("_definitions", "")
 
         if link.endswith(".zip"):
-            download_path = self.download_directory / f"msha_{filename}.zip"
+            download_path = self.download_directory / f"{self.name}-{filename}.zip"
             await self.download_zipfile(link, download_path)
 
         elif link.endswith(".txt"):
-            download_path = self.download_directory / f"msha_{filename}.txt"
+            download_path = self.download_directory / f"{self.name}-{filename}.txt"
             await self.download_file(link, download_path)
 
         elif link.endswith(".xlsx"):
-            download_path = self.download_directory / f"msha_{filename}.xlsx"
+            download_path = self.download_directory / f"{self.name}-{filename}.xlsx"
             await self.download_file(link, download_path)
 
         else:

--- a/src/pudl_archiver/archivers/phmsagas.py
+++ b/src/pudl_archiver/archivers/phmsagas.py
@@ -66,18 +66,18 @@ class PhmsaGasArchiver(AbstractDatasetArchiver):
         For example: annual_underground_natural_gas_storage_2017_present.zip
         """
         url = f"https://www.phmsa.dot.gov/{link}"
-        file = str(match.group(1)).replace("-", "_")  # Get file name
+        filename = str(match.group(1)).replace("-", "_")  # Get file name
 
         # Set dataset partition
-        dataset = "_".join(file.lower().split("_")[0:-2])
+        dataset = "_".join(filename.lower().split("_")[0:-2])
 
         if dataset not in PHMSA_DATASETS:
             logger.warning(f"New dataset type found: {dataset}.")
 
         # Set start year
-        start_year = int(file.split("_")[-2])
+        start_year = int(filename.split("_")[-2])
 
-        download_path = self.download_directory / f"phmsagas_{file}.zip"
+        download_path = self.download_directory / f"{self.name}-{filename}.zip"
         await self.download_zipfile(url, download_path)
 
         return ResourceInfo(


### PR DESCRIPTION
Tweak the archive filenames slightly to match naming patterns from other archivers.

Add new production DOIs for:
* `eia176`
* `eiawater`
* `mshamines`
* `phmsagas`

I used these archivers to initialize archives on the production Zenodo site, and also updated a bunch of other archivers (See #79). However, I didn't update the FERC archives because of the issue with unique IDs in the RSS feeds described in #73.

Closes #79 