### PR TITLE
Make partitions (data_format) lowercase when building archives

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -39,7 +39,7 @@ class Ferc2Archiver(AbstractDatasetArchiver):
         )
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year": year, "data_format": "XBRL"}
+            local_path=download_path, partitions={"year": year, "data_format": "xbrl"}
         )
 
     async def get_year_dbf(
@@ -80,5 +80,5 @@ class Ferc2Archiver(AbstractDatasetArchiver):
 
         return ResourceInfo(
             local_path=download_path,
-            partitions={"year": year, "data_format": "DBF", "part": part},
+            partitions={"year": year, "data_format": "dbf", "part": part},
         )

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -32,7 +32,7 @@ class Ferc6Archiver(AbstractDatasetArchiver):
         )
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year": year, "data_format": "XBRL"}
+            local_path=download_path, partitions={"year": year, "data_format": "xbrl"}
         )
 
     async def get_year_dbf(self, year: int) -> tuple[Path, dict]:
@@ -42,5 +42,5 @@ class Ferc6Archiver(AbstractDatasetArchiver):
         await self.download_zipfile(url, download_path)
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year": year, "data_format": "DBF"}
+            local_path=download_path, partitions={"year": year, "data_format": "dbf"}
         )

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -32,7 +32,7 @@ class Ferc60Archiver(AbstractDatasetArchiver):
         )
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year": year, "data_format": "XBRL"}
+            local_path=download_path, partitions={"year": year, "data_format": "xbrl"}
         )
 
     async def get_year_dbf(self, year: int) -> tuple[Path, dict]:
@@ -42,5 +42,5 @@ class Ferc60Archiver(AbstractDatasetArchiver):
         await self.download_zipfile(url, download_path)
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year": year, "data_format": "DBF"}
+            local_path=download_path, partitions={"year": year, "data_format": "dbf"}
         )

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -31,7 +31,7 @@ class Ferc714Archiver(AbstractDatasetArchiver):
         )
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year": year, "data_format": "XBRL"}
+            local_path=download_path, partitions={"year": year, "data_format": "xbrl"}
         )
 
     async def get_bulk_csv(self) -> tuple[Path, dict]:


### PR DESCRIPTION
What it says on the tin. Make sure to use lowercase values for `data_format` partition.