### PR TITLE
Point crosswalk archive at our mirror with 2021 outputs

### DIFF
--- a/src/pudl_archiver/archivers/epacamd_eia.py
+++ b/src/pudl_archiver/archivers/epacamd_eia.py
@@ -19,9 +19,7 @@ class EpaCamdEiaArchiver(AbstractDatasetArchiver):
 
     async def get_crosswalk_zip(self) -> tuple[Path, dict]:
         """Download entire repo as a zipfile from github."""
-        url = (
-            "https://github.com/USEPA/camd-eia-crosswalk/archive/refs/heads/master.zip"
-        )
+        url = "https://github.com/catalyst-cooperative/camd-eia-crosswalk-2021/archive/refs/heads/main.zip"
         download_path = self.download_directory / "epacamd_eia.zip"
         await self.download_zipfile(url, download_path)
 

--- a/src/pudl_archiver/archivers/epacamd_eia.py
+++ b/src/pudl_archiver/archivers/epacamd_eia.py
@@ -15,12 +15,22 @@ class EpaCamdEiaArchiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EPA CAMD to EIA crosswalk resources."""
-        yield self.get_crosswalk_zip()
+        for year in [2018, 2021]:
+            yield self.get_crosswalk_zip(year)
 
-    async def get_crosswalk_zip(self) -> tuple[Path, dict]:
-        """Download entire repo as a zipfile from github."""
-        url = "https://github.com/catalyst-cooperative/camd-eia-crosswalk-2021/archive/refs/heads/main.zip"
-        download_path = self.download_directory / "epacamd_eia.zip"
-        await self.download_zipfile(url, download_path)
+    async def get_crosswalk_zip(self, year: int) -> tuple[Path, dict]:
+        """Download entire repo as a zipfile from github.
 
-        return ResourceInfo(local_path=download_path, partitions={})
+        For the version of the crosswalk using 2018 data, download the base EPA repo. For 2021 outputs
+        use our fork. If we decide to archive more years we can add infrastructure to dynamically run
+        the crosswalk and only archive the outputs, but for now this is the simplest way to archive
+        the years in use.
+        """
+        crosswalk_urls = {
+            2018: "https://github.com/USEPA/camd-eia-crosswalk/archive/refs/heads/master.zip",
+            2021: "https://github.com/catalyst-cooperative/camd-eia-crosswalk-2021/archive/refs/heads/main.zip",
+        }
+        download_path = self.download_directory / f"epacamd_eia_{year}.zip"
+        await self.download_zipfile(crosswalk_urls[year], download_path)
+
+        return ResourceInfo(local_path=download_path, partitions={"year": year})


### PR DESCRIPTION
This PR updates the `epacamd_eia` archiver to archive 2021 data by downloading a zip of our forked crosswalk repo, which contains the 2021 outputs.