### PR TITLE
Update eia860 regex

### DIFF
--- a/src/pudl_archiver/archivers/eia860.py
+++ b/src/pudl_archiver/archivers/eia860.py
@@ -19,7 +19,7 @@ class Eia860Archiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EIA-860 resources."""
-        link_pattern = re.compile(r"eia860(\d{4}(ER)*).zip")
+        link_pattern = re.compile(r"eia860(\d{4})(ER)*.zip")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
             yield self.get_year_resource(link, link_pattern.search(link))
 

--- a/src/pudl_archiver/archivers/eia860.py
+++ b/src/pudl_archiver/archivers/eia860.py
@@ -19,7 +19,7 @@ class Eia860Archiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EIA-860 resources."""
-        link_pattern = re.compile(r"eia860(\d{4}).zip")
+        link_pattern = re.compile(r"eia860(\d{4}(ER)*).zip")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
             yield self.get_year_resource(link, link_pattern.search(link))
 


### PR DESCRIPTION
Add regex to identify early release data links that were previously unmarked. Now contain ER in the link name: `eia860-2022ER.zip`