### PR TITLE
Download data from specific years to a specific location

### DIFF
--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -33,6 +33,7 @@ async def archive_datasets(
     datasets: list[str],
     sandbox: bool = True,
     initialize: bool = False,
+    only_years: list[int] | None = None,
     dry_run: bool = True,
     summary_file: str | None = None,
 ):
@@ -55,7 +56,7 @@ async def archive_datasets(
             if not cls:
                 raise RuntimeError(f"Dataset {dataset} not supported")
             else:
-                downloader = cls(session)
+                downloader = cls(session, only_years)
             orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -36,6 +36,7 @@ async def archive_datasets(
     only_years: list[int] | None = None,
     dry_run: bool = True,
     summary_file: str | None = None,
+    download_dir: str | None = None,
 ):
     """A CLI for the PUDL Zenodo Storage system."""
     if sandbox:
@@ -56,7 +57,7 @@ async def archive_datasets(
             if not cls:
                 raise RuntimeError(f"Dataset {dataset} not supported")
             else:
-                downloader = cls(session, only_years)
+                downloader = cls(session, only_years, download_directory=download_dir)
             orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -54,7 +54,9 @@ class AbstractDatasetArchiver(ABC):
     # Configurable option to run _check_missing_files during archive validation
     check_missing_files: bool = True
 
-    def __init__(self, session: aiohttp.ClientSession):
+    def __init__(
+        self, session: aiohttp.ClientSession, only_years: list[int] | None = None
+    ):
         """Initialize Archiver object.
 
         Args:
@@ -65,6 +67,9 @@ class AbstractDatasetArchiver(ABC):
         # Create a temporary directory for downloading data
         self._download_directory_manager = tempfile.TemporaryDirectory()
         self.download_directory = Path(self._download_directory_manager.name)
+        if only_years is None:
+            only_years = []
+        self.only_years = only_years
 
         # Create logger
         self.logger = logging.getLogger(f"catalystcoop.{__name__}")
@@ -231,6 +236,9 @@ class AbstractDatasetArchiver(ABC):
     ) -> list[ValidationTestResult]:
         """Hook to add archive validation tests specific to each dataset."""
         return []
+
+    def valid_year(self, year: int | str):
+        return (not self.only_years) or int(year) in self.only_years
 
     async def download_all_resources(self) -> dict[str, ResourceInfo]:
         """Download all resources.

--- a/src/pudl_archiver/archivers/eia860.py
+++ b/src/pudl_archiver/archivers/eia860.py
@@ -21,15 +21,14 @@ class Eia860Archiver(AbstractDatasetArchiver):
         """Download EIA-860 resources."""
         link_pattern = re.compile(r"eia860(\d{4})(ER)*.zip")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            yield self.get_year_resource(link, link_pattern.search(link))
+            year = link_pattern.search(link).group(1)
+            if self.valid_year(year):
+                yield self.get_year_resource(link, link_pattern.search(link))
 
-    async def get_year_resource(
-        self, link: str, match: typing.Match
-    ) -> tuple[Path, dict]:
+    async def get_year_resource(self, link: str, year: int) -> tuple[Path, dict]:
         """Download zip file."""
         # Append hyperlink to base URL to get URL of file
         url = f"{BASE_URL}/{link}"
-        year = match.group(1)
         download_path = self.download_directory / f"eia860-{year}.zip"
         await self.download_zipfile(url, download_path)
 

--- a/src/pudl_archiver/archivers/eia860.py
+++ b/src/pudl_archiver/archivers/eia860.py
@@ -1,6 +1,5 @@
 """Download EIA-860 data."""
 import re
-import typing
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (

--- a/src/pudl_archiver/archivers/eia860m.py
+++ b/src/pudl_archiver/archivers/eia860m.py
@@ -1,7 +1,6 @@
 """Download EIA-860M data."""
 import calendar
 import re
-import typing
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (

--- a/src/pudl_archiver/archivers/eia860m.py
+++ b/src/pudl_archiver/archivers/eia860m.py
@@ -26,15 +26,17 @@ class Eia860MArchiver(AbstractDatasetArchiver):
         link_pattern = re.compile(r"([a-z]+)_generator(\d{4}).xlsx")
 
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            yield self.get_year_month_resource(link, link_pattern.search(link))
+            match = link_pattern.search(link)
+            year = int(match.group(2))
+            month = self.month_map[match.group(1)]
+            if self.valid_year(year):
+                yield self.get_year_month_resource(link, year, month)
 
     async def get_year_month_resource(
-        self, link: str, match: typing.Match
+        self, link: str, year: int, month: int
     ) -> tuple[Path, dict]:
         """Download xlsx file."""
         url = f"https://eia.gov/{link}"
-        year = match.group(2)
-        month = self.month_map[match.group(1)]
         download_path = self.download_directory / f"eia860m-{year}-{month:02}.xlsx"
         await self.download_file(url, download_path)
 

--- a/src/pudl_archiver/archivers/eia861.py
+++ b/src/pudl_archiver/archivers/eia861.py
@@ -22,21 +22,20 @@ class Eia861Archiver(AbstractDatasetArchiver):
         link_pattern = re.compile(r"f861(\d{2,4}).zip")
 
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            yield self.get_year_resource(link, link_pattern.search(link))
+            year = int(link_pattern.search(link).group(1))
+            # Older file names only have last two digits of year in name
+            # Convert to 4-digit years
+            if year < 100 and year >= 90:
+                year += 1900
+            elif year < 100 and year < 90:
+                year += 2000
+            if self.valid_year(year):
+                yield self.get_year_resource(link, year)
 
-    async def get_year_resource(
-        self, link: str, match: typing.Match
-    ) -> tuple[Path, dict]:
+    async def get_year_resource(self, link: str, year: int) -> tuple[Path, dict]:
         """Download zip file."""
         # Use archive link if year is not most recent year
         url = f"{BASE_URL}/{link}"
-        year = int(match.group(1))
-        # Older file names only have last two digits of year in name
-        # Convert to 4-digit years
-        if year < 100 and year >= 90:
-            year += 1900
-        elif year < 100 and year < 90:
-            year += 2000
         download_path = self.download_directory / f"eia861-{year}.zip"
         await self.download_zipfile(url, download_path)
 

--- a/src/pudl_archiver/archivers/eia861.py
+++ b/src/pudl_archiver/archivers/eia861.py
@@ -1,6 +1,5 @@
 """Download EIA-861 data."""
 import re
-import typing
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (
@@ -29,6 +28,7 @@ class Eia861Archiver(AbstractDatasetArchiver):
                 year += 1900
             elif year < 100 and year < 90:
                 year += 2000
+                print(year)
             if self.valid_year(year):
                 yield self.get_year_resource(link, year)
 

--- a/src/pudl_archiver/archivers/eia861.py
+++ b/src/pudl_archiver/archivers/eia861.py
@@ -26,9 +26,8 @@ class Eia861Archiver(AbstractDatasetArchiver):
             # Convert to 4-digit years
             if year < 100 and year >= 90:
                 year += 1900
-            elif year < 100 and year < 90:
+            elif year < 90:
                 year += 2000
-                print(year)
             if self.valid_year(year):
                 yield self.get_year_resource(link, year)
 

--- a/src/pudl_archiver/archivers/eia923.py
+++ b/src/pudl_archiver/archivers/eia923.py
@@ -1,6 +1,5 @@
 """Download EIA-923 data."""
 import re
-import typing
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (
@@ -26,9 +25,7 @@ class Eia923Archiver(AbstractDatasetArchiver):
             if self.valid_year(year):
                 yield self.get_year_resource(link, year)
 
-    async def get_year_resource(
-        self, link: str, year: int
-    ) -> tuple[Path, dict]:
+    async def get_year_resource(self, link: str, year: int) -> tuple[Path, dict]:
         """Download zip file."""
         url = f"{BASE_URL}/{link}"
         download_path = self.download_directory / f"eia923-{year}.zip"

--- a/src/pudl_archiver/archivers/eia923.py
+++ b/src/pudl_archiver/archivers/eia923.py
@@ -22,14 +22,15 @@ class Eia923Archiver(AbstractDatasetArchiver):
         link_pattern = re.compile(r"f((923)|(906920))_(\d{4})\.zip")
 
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            yield self.get_year_resource(link, link_pattern.search(link))
+            year = int(link_pattern.search(link).group(4))
+            if self.valid_year(year):
+                yield self.get_year_resource(link, year)
 
     async def get_year_resource(
-        self, link: str, match: typing.Match
+        self, link: str, year: int
     ) -> tuple[Path, dict]:
         """Download zip file."""
         url = f"{BASE_URL}/{link}"
-        year = match.group(4)
         download_path = self.download_directory / f"eia923-{year}.zip"
         await self.download_zipfile(url, download_path)
 

--- a/src/pudl_archiver/archivers/eiawater.py
+++ b/src/pudl_archiver/archivers/eiawater.py
@@ -24,17 +24,17 @@ class EiaWaterArchiver(AbstractDatasetArchiver):
         link_pattern = re.compile(r"[Cc]ooling\w+([Ss]ummary|[Dd]etail)_(\d{4})\.xlsx")
 
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            yield self.get_year_resource(link, link_pattern.search(link))
+            match = link_pattern.search(link)
+            table = match.group(1).lower()
+            year = int(match.group(2))
+            if self.valid_year(year):
+                yield self.get_year_resource(link, table, year)
 
     async def get_year_resource(
-        self, link: str, match: typing.Match
+        self, link: str, table: str, year: int
     ) -> tuple[Path, dict]:
         """Download zip file."""
         url = f"{BASE_URL}/{link}"
-
-        table = match.group(1).lower()
-        year = match.group(2)
-
         download_path = self.download_directory / f"eiawater-{year}-{table}.xlsx"
         await self.download_file(url, download_path)
 

--- a/src/pudl_archiver/archivers/eiawater.py
+++ b/src/pudl_archiver/archivers/eiawater.py
@@ -1,7 +1,6 @@
 """Download EIA Thermal Cooling Water data."""
 import logging
 import re
-import typing
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (

--- a/src/pudl_archiver/archivers/epacems.py
+++ b/src/pudl_archiver/archivers/epacems.py
@@ -82,8 +82,6 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
         # Loop through all available years of data
         for year in await self.get_hyperlinks(BASE_URL, year_pattern, verify=False):
             year = int(year[:-1])
-            if not self.valid(year):
-                continue
             # Store months available for each state
             states = {state: [] for state in STATE_ABBREVIATIONS}
             for link in await self.get_hyperlinks(

--- a/src/pudl_archiver/archivers/epacems.py
+++ b/src/pudl_archiver/archivers/epacems.py
@@ -82,6 +82,8 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
         # Loop through all available years of data
         for year in await self.get_hyperlinks(BASE_URL, year_pattern, verify=False):
             year = int(year[:-1])
+            if not self.valid(year):
+                continue
             # Store months available for each state
             states = {state: [] for state in STATE_ABBREVIATIONS}
             for link in await self.get_hyperlinks(

--- a/src/pudl_archiver/archivers/ferc/ferc1.py
+++ b/src/pudl_archiver/archivers/ferc/ferc1.py
@@ -17,11 +17,13 @@ class Ferc1Archiver(AbstractDatasetArchiver):
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 1 resources."""
         for year in range(1994, 2022):
-            yield self.get_year_dbf(year)
+            if self.valid_year(year):
+                yield self.get_year_dbf(year)
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_1]
         for year, year_filings in filings.items():
-            yield self.get_year_xbrl(year, year_filings)
+            if self.valid_year(year):
+                yield self.get_year_xbrl(year, year_filings)
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -18,11 +18,15 @@ class Ferc2Archiver(AbstractDatasetArchiver):
         """Download FERC 2 resources."""
         # Get sub-annually partitioned DBF data
         for year in range(1991, 2000):
+            if not self.valid_year(year):
+                continue
             for part in [1, 2]:
                 yield self.get_year_dbf(year, part)
 
         # Get annually partitioned DBF data
         for year in range(1996, 2022):
+            if not self.valid_year(year):
+                continue
             yield self.get_year_dbf(year)
 
         # Get XBRL filings

--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -32,6 +32,8 @@ class Ferc2Archiver(AbstractDatasetArchiver):
         # Get XBRL filings
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_2]
         for year, year_filings in filings.items():
+            if not self.valid_year(year):
+                continue
             yield self.get_year_xbrl(year, year_filings)
 
     async def get_year_xbrl(

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -17,6 +17,8 @@ class Ferc6Archiver(AbstractDatasetArchiver):
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 6 resources."""
         for year in range(2000, 2022):
+            if not self.valid_year(year):
+                continue
             yield self.get_year_dbf(year)
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_6]

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -23,6 +23,8 @@ class Ferc6Archiver(AbstractDatasetArchiver):
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_6]
         for year, year_filings in filings.items():
+            if not self.valid_year(year):
+                continue
             yield self.get_year_xbrl(year, year_filings)
 
     async def get_year_xbrl(

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -23,6 +23,8 @@ class Ferc60Archiver(AbstractDatasetArchiver):
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_60]
         for year, year_filings in filings.items():
+            if not self.valid_year(year):
+                continue
             yield self.get_year_xbrl(year, year_filings)
 
     async def get_year_xbrl(

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -17,6 +17,8 @@ class Ferc60Archiver(AbstractDatasetArchiver):
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 60 resources."""
         for year in range(2006, 2021):
+            if not self.valid_year(year):
+                continue
             yield self.get_year_dbf(year)
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_60]

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -20,6 +20,8 @@ class Ferc714Archiver(AbstractDatasetArchiver):
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_714]
         for year, year_filings in filings.items():
+            if not self.valid_year(year):
+                continue
             yield self.get_year_xbrl(year, year_filings)
 
     async def get_year_xbrl(

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -55,6 +55,11 @@ def parse_main():
         type=str,
         help="Generate a JSON archive run summary",
     )
+    parser.add_argument(
+        "--download-dir",
+        help="Directory to download files to. Use tmpdir if not specified.",
+        default=None,
+    )
     return parser.parse_args()
 
 

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -26,7 +26,7 @@ def parse_main():
         "--only-years",
         nargs="*",
         help="Years to download data for. Supported datasets: eia860, "
-        "eia860m, eia861, eia923, eiawater, epacems, ferc1, ferc2, ferc6, "
+        "eia860m, eia861, eia923, eiawater, ferc1, ferc2, ferc6, "
         "ferc60, ferc714",
         type=int,
     )

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -23,6 +23,14 @@ def parse_main():
         choices=list(ARCHIVERS.keys()),
     )
     parser.add_argument(
+        "--only-years",
+        nargs="*",
+        help="Years to download data for. Supported datasets: eia860, "
+        "eia860m, eia861, eia923, eiawater, epacems, ferc1, ferc2, ferc6, "
+        "ferc60, ferc714",
+        type=int,
+    )
+    parser.add_argument(
         "--all",
         action="store_true",
         help="Run all defined archivers.",

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -48,8 +48,9 @@ class MockArchiver(AbstractDatasetArchiver):
 
     name = "test_archiver"
 
-    def __init__(self, test_results):
+    def __init__(self, test_results, **kwargs):
         self.test_results = test_results
+        super().__init__(session=None, **kwargs)
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Create fake resources."""
@@ -362,3 +363,14 @@ def test_check_missing_files(datapackage, baseline_resources, new_resources, suc
         baseline_datapackage, new_datapackage
     )
     assert validation_result.success == success
+
+
+def test_year_filter():
+    archiver = MockArchiver(None, only_years=[2020, 2022])
+    assert archiver.valid_year(2020)
+    assert not archiver.valid_year(2021)
+    assert archiver.valid_year(2022)
+    assert archiver.valid_year("2022")
+
+    archiver_no_filter = MockArchiver(None)
+    assert archiver_no_filter.valid_year(2021)

--- a/tests/unit/eia_archiver_test.py
+++ b/tests/unit/eia_archiver_test.py
@@ -1,0 +1,88 @@
+import pytest
+
+from pudl_archiver.archivers.eia860 import Eia860Archiver
+from pudl_archiver.archivers.eia860m import Eia860MArchiver
+from pudl_archiver.archivers.eia861 import Eia861Archiver
+from pudl_archiver.archivers.eia923 import Eia923Archiver
+
+
+@pytest.mark.asyncio
+async def test_eia860(mocker):
+    mock_session = mocker.AsyncMock()
+    urls = [
+        f"https://www.eia.gov/electricity/data/eia860/xls/eia860{y}.zip"
+        for y in range(2000, 2023)
+    ]
+    get_hyperlinks = mocker.AsyncMock(return_value=urls)
+    mocker.patch(
+        "pudl_archiver.archivers.eia860.Eia860Archiver.get_hyperlinks",
+        get_hyperlinks,
+    )
+    archiver = Eia860Archiver(mock_session, only_years=[2019, 2022])
+    resources = [res async for res in archiver.get_resources()]
+    assert len(resources) == 2
+
+
+@pytest.mark.asyncio
+async def test_eia860m(mocker):
+    mock_session = mocker.AsyncMock()
+    urls = [
+        f"https://www.eia.gov/electricity/data/eia860m/xls/{m}_generator{y}.xlsx"
+        for y in range(2000, 2023)
+        for m in [
+            "january",
+            "february",
+            "march",
+            "april",
+            "may",
+            "june",
+            "july",
+            "august",
+            "september",
+            "october",
+            "november",
+            "december",
+        ]
+    ]
+    get_hyperlinks = mocker.AsyncMock(return_value=urls)
+    mocker.patch(
+        "pudl_archiver.archivers.eia860m.Eia860MArchiver.get_hyperlinks",
+        get_hyperlinks,
+    )
+    archiver = Eia860MArchiver(mock_session, only_years=[2019, 2022])
+    resources = [res async for res in archiver.get_resources()]
+    assert len(resources) == 24
+
+
+@pytest.mark.asyncio
+async def test_eia861(mocker):
+    mock_session = mocker.AsyncMock()
+    urls = [
+        f"https://www.eia.gov/electricity/data/eia861/zip/f861{y}.zip"
+        for y in [95, 96, 11, 12, 2019, 2022]
+    ]
+    get_hyperlinks = mocker.AsyncMock(return_value=urls)
+    mocker.patch(
+        "pudl_archiver.archivers.eia861.Eia861Archiver.get_hyperlinks",
+        get_hyperlinks,
+    )
+    archiver = Eia861Archiver(mock_session, only_years=[2019, 2022])
+    resources = [res async for res in archiver.get_resources()]
+    assert len(resources) == 2
+
+
+@pytest.mark.asyncio
+async def test_eia923(mocker):
+    mock_session = mocker.AsyncMock()
+    urls = [
+        f"https://www.eia.gov/electricity/data/eia923/zip/f923_{y}.zip"
+        for y in range(2002, 2023)
+    ]
+    get_hyperlinks = mocker.AsyncMock(return_value=urls)
+    mocker.patch(
+        "pudl_archiver.archivers.eia923.Eia923Archiver.get_hyperlinks",
+        get_hyperlinks,
+    )
+    archiver = Eia923Archiver(mock_session, only_years=[2019, 2022])
+    resources = [res async for res in archiver.get_resources()]
+    assert len(resources) == 2

--- a/tests/unit/eiawater_test.py
+++ b/tests/unit/eiawater_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pudl_archiver.archivers.eiawater import EiaWaterArchiver
+
+
+@pytest.mark.asyncio
+async def test_eiawater_filter_years(mocker):
+    mock_session = mocker.AsyncMock()
+    urls = [
+        f"https://www.eia.gov/electricity/data/water/xls/Cooling_Boiler_Generator_Data_Summary_{y}.xlsx"
+        for y in range(2000, 2023)
+    ]
+    get_hyperlinks = mocker.AsyncMock(return_value=urls)
+    mocker.patch(
+        "pudl_archiver.archivers.eiawater.EiaWaterArchiver.get_hyperlinks",
+        get_hyperlinks,
+    )
+    archiver = EiaWaterArchiver(mock_session, only_years=[2019, 2022])
+    resources = [res async for res in archiver.get_resources()]
+    assert len(resources) == 2

--- a/tests/unit/ferc_archiver_test.py
+++ b/tests/unit/ferc_archiver_test.py
@@ -1,0 +1,76 @@
+import pytest
+
+from pudl_archiver.archivers.ferc.ferc1 import Ferc1Archiver
+from pudl_archiver.archivers.ferc.ferc2 import Ferc2Archiver
+from pudl_archiver.archivers.ferc.ferc6 import Ferc6Archiver
+from pudl_archiver.archivers.ferc.ferc60 import Ferc60Archiver
+from pudl_archiver.archivers.ferc.ferc714 import Ferc714Archiver
+from pudl_archiver.archivers.ferc.xbrl import FercForm
+
+FERC_FORM_CLASS_LOOKUP = {
+    "ferc1": (FercForm.FORM_1, Ferc1Archiver),
+    "ferc2": (FercForm.FORM_2, Ferc2Archiver),
+    "ferc6": (FercForm.FORM_6, Ferc6Archiver),
+    "ferc60": (FercForm.FORM_60, Ferc60Archiver),
+    "ferc714": (FercForm.FORM_714, Ferc714Archiver),
+}
+
+
+def make_testdata(module_test_spec_dict):
+    testdata = [
+        (name, spec) for name, specs in module_test_spec_dict.items() for spec in specs
+    ]
+    return testdata
+
+
+valid_years_test_spec_dict = {
+    "ferc1": [
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1},
+        {"years": [2003, 2004, 2005, 2021], "num_dbf": 4, "num_xbrl": 2},
+    ],
+    "ferc2": [
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1},
+        {"years": [2003, 2004, 2005, 2021], "num_dbf": 4, "num_xbrl": 2},
+    ],
+    "ferc6": [
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1},
+        {"years": [2003, 2004, 2005, 2021], "num_dbf": 4, "num_xbrl": 2},
+    ],
+    "ferc60": [
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 0, "num_xbrl": 1},
+        {"years": [2004, 2005, 2006, 2007, 2021], "num_dbf": 2, "num_xbrl": 2},
+    ],
+    "ferc714": [
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 0, "num_xbrl": 1},
+        {"years": [2004, 2005, 2006, 2007, 2021], "num_dbf": 0, "num_xbrl": 2},
+    ],
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "module_name,test_spec", make_testdata(valid_years_test_spec_dict)
+)
+async def test_valid_years(module_name, test_spec, mocker):
+    form_name, form_class = FERC_FORM_CLASS_LOOKUP[module_name]
+    only_years = test_spec["years"]
+    num_dbf = test_spec["num_dbf"]
+    num_xbrl = test_spec["num_xbrl"]
+
+    mocker.patch(
+        f"pudl_archiver.archivers.ferc.{module_name}.xbrl.index_available_entries",
+        lambda: {form_name: {2004: mocker.MagicMock(), 2021: mocker.MagicMock()}},
+    )
+    mock_session = mocker.AsyncMock()
+    archiver = form_class(mock_session, only_years=only_years)
+    resources = [res async for res in archiver.get_resources()]
+    # don't await these, just check to make sure they have right intention
+    dbfs = [r for r in resources if r.__name__ == "get_year_dbf"]
+    xbrls = [r for r in resources if r.__name__ == "get_year_xbrl"]
+    assert len(dbfs) == num_dbf
+    assert len(xbrls) == num_xbrl


### PR DESCRIPTION
When investigating the FERC 2022 data for catalyst-cooperative/pudl#2766, I found that it was hard to "Just get the raw 2022 FERC 1 XBRL data and save it somewhere on disk where I can mess with it."

This adds:
* yearly filtering for the datasets where that was easy to do
* ability to dump the downloaded file to a non-temporary directory