### PR TITLE
Update EIA 861 archiver to capture 2022 early release data

### DIFF
--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -8,6 +8,7 @@ import aiohttp
 
 import pudl_archiver.orchestrator  # noqa: 401
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver
+from pudl_archiver.archivers.validate import Unchanged
 from pudl_archiver.orchestrator import DepositionOrchestrator
 
 
@@ -72,7 +73,9 @@ async def archive_datasets(
 
             tasks.append(orchestrator.run())
 
-        results = zip(datasets, await asyncio.gather(*tasks, return_exceptions=True))
+        results = list(
+            zip(datasets, await asyncio.gather(*tasks, return_exceptions=True))
+        )
         exceptions = [
             (dataset, result)
             for dataset, result in results
@@ -90,6 +93,9 @@ async def archive_datasets(
         with open(summary_file, "w") as f:
             json.dump(run_summaries, f, indent=2)
 
-    validation_results = [result.success for _, result in results]
+    # Check validation results of all runs that aren't unchanged
+    validation_results = [
+        result.success for _, result in results if not isinstance(result, Unchanged)
+    ]
     if not all(validation_results):
         raise RuntimeError("Error: archive validation tests failed.")

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -73,8 +73,8 @@ class AbstractDatasetArchiver(ABC):
         # Create a temporary directory for downloading data
 
         if download_directory is None:
-            tmpdir = tempfile.TemporaryDirectory()
-            self.download_directory = Path(tmpdir.name)
+            self.download_directory_manager = tempfile.TemporaryDirectory()
+            self.download_directory = Path(self.download_directory_manager.name)
         else:
             self.download_directory = Path(download_directory)
 

--- a/src/pudl_archiver/archivers/eia861.py
+++ b/src/pudl_archiver/archivers/eia861.py
@@ -18,7 +18,7 @@ class Eia861Archiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EIA-861 resources."""
-        link_pattern = re.compile(r"f861(\d{2,4}).zip")
+        link_pattern = re.compile(r"f861(\d{2,4})(er)*.zip")
 
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
             year = int(link_pattern.search(link).group(1))

--- a/tests/unit/pudl_archiver_test.py
+++ b/tests/unit/pudl_archiver_test.py
@@ -1,0 +1,82 @@
+"""Test archiver pudl_archiver."""
+import pytest
+
+from pudl_archiver import archive_datasets
+from pudl_archiver.archivers.validate import RunSummary, Unchanged, ValidationTestResult
+
+
+@pytest.fixture()
+def unchanged_run():
+    """Return a run_summary with a success."""
+    return Unchanged(dataset_name="success")
+
+
+@pytest.fixture()
+def successful_run():
+    """Return a run_summary with a success."""
+    return RunSummary(
+        dataset_name="success",
+        validation_tests=[
+            ValidationTestResult(
+                name="succesful_test",
+                description="succesful test",
+                success=True,
+            )
+        ],
+        file_changes=[],
+        date="date",
+        previous_version_date="date",
+    )
+
+
+@pytest.fixture()
+def failed_run():
+    """Return a run_summary with a success."""
+    return RunSummary(
+        dataset_name="failure",
+        validation_tests=[
+            ValidationTestResult(
+                name="failure_test",
+                description="failure test",
+                success=False,
+            )
+        ],
+        file_changes=[],
+        date="date",
+        previous_version_date="date",
+    )
+
+
+@pytest.mark.asyncio
+async def test_archive_datasets(successful_run, failed_run, unchanged_run, mocker):
+    """Test that archive datasets creates run_summary file."""
+    open_mock = mocker.patch("pudl_archiver.open")
+    open_mock.return_value.__enter__.return_value = "file"
+    mocked_json_dump = mocker.patch("pudl_archiver.json.dump")
+
+    # Set run() return value to success summary and test
+    mocked_orchestrator_success = mocker.AsyncMock(return_value=successful_run)
+    mocker.patch(
+        "pudl_archiver.DepositionOrchestrator.run", new=mocked_orchestrator_success
+    )
+    await archive_datasets(["eia860"], summary_file="file")
+    mocked_json_dump.assert_called_once_with([successful_run.dict()], "file", indent=2)
+
+    # Set run() return value to failure summary and test
+    mocked_json_dump.reset_mock()
+    mocked_orchestrator_fail = mocker.AsyncMock(return_value=failed_run)
+    mocker.patch(
+        "pudl_archiver.DepositionOrchestrator.run", new=mocked_orchestrator_fail
+    )
+    with pytest.raises(RuntimeError):
+        await archive_datasets(["eia860"], summary_file="file")
+    mocked_json_dump.assert_called_once_with([failed_run.dict()], "file", indent=2)
+
+    # Set run() return value to unchanged summary and test
+    mocked_json_dump.reset_mock()
+    mocked_orchestrator_unchanged = mocker.AsyncMock(return_value=unchanged_run)
+    mocker.patch(
+        "pudl_archiver.DepositionOrchestrator.run", new=mocked_orchestrator_unchanged
+    )
+    await archive_datasets(["eia860"], summary_file="file")
+    mocked_json_dump.assert_called_once_with([unchanged_run.dict()], "file", indent=2)


### PR DESCRIPTION
This PR does a collection of things:
1) Fixes an issue with the temporary directory from #139 
2) Adds an early release suffix to the regex command to include 2022 early release data in the archive download
3) Fixes an issue with the `--summary-file` flag, which was writing empty files.

Jumped the gun a bit and used this to run both sandbox and production before review, but works as expected.
