### PR TITLE
Ferceqr doi

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -49,3 +49,5 @@ mshamines:
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
   sandbox_doi: 10.5072/zenodo.1161321
+ferceqr:
+  sandbox_doi: 10.5072/zenodo.1232114

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -77,6 +77,11 @@ async def archive_datasets(
                 raise RuntimeError(f"Dataset {dataset} not supported")
             else:
                 downloader = cls(session, only_years, download_directory=download_dir)
+
+            if dataset == "ferceqr":
+                sandbox = False
+                initialize = True
+
             orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -59,6 +59,8 @@ async def archive_datasets(
                 raise RuntimeError(f"Dataset {dataset} not supported")
             else:
                 downloader = cls(session, only_years, download_directory=download_dir)
+            if dataset == "ferceqr":
+                initialize = True
             orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -77,8 +77,6 @@ async def archive_datasets(
                 raise RuntimeError(f"Dataset {dataset} not supported")
             else:
                 downloader = cls(session, only_years, download_directory=download_dir)
-            if dataset == "ferceqr":
-                initialize = True
             orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -146,8 +146,9 @@ class AbstractDatasetArchiver(ABC):
             file: Local path to write file to disk or bytes object to save file in memory.
             kwargs: Key word args to pass to request.
         """
+        kwargs["timeout"] = 300
         response_bytes = await retry_async(
-            get_read, args=[self.session, [url]], kwargs=kwargs
+            get_read, args=[self.session, url], kwargs=kwargs
         )
         if isinstance(file, Path):
             with open(file, "wb") as f:

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -18,7 +18,7 @@ from pudl_archiver.archivers.validate import (
     ValidationTestResult,
 )
 from pudl_archiver.frictionless import DataPackage, ResourceInfo
-from pudl_archiver.utils import retry_async
+from pudl_archiver.utils import get_read, retry_async
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
 
@@ -146,8 +146,9 @@ class AbstractDatasetArchiver(ABC):
             file: Local path to write file to disk or bytes object to save file in memory.
             kwargs: Key word args to pass to request.
         """
-        response = await retry_async(self.session.get, args=[url], kwargs=kwargs)
-        response_bytes = await retry_async(response.read)
+        response_bytes = await retry_async(
+            get_read, args=[self.session, [url]], kwargs=kwargs
+        )
         if isinstance(file, Path):
             with open(file, "wb") as f:
                 f.write(response_bytes)

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -371,6 +371,6 @@ class AbstractDatasetArchiver(ABC):
 
             # If requested, create a new temporary directory per resource chunk
             if self.directory_per_resource_chunk:
-                tmp_dir = tempfile.TemporaryDirectory()
-                self.download_directory = Path(tmp_dir.name)
+                self.download_directory_manager = tempfile.TemporaryDirectory()
+                self.download_directory = Path(self.download_directory_manager.name)
                 self.logger.info(f"New download directory {self.download_directory}")

--- a/src/pudl_archiver/archivers/ferc/ferceqr.py
+++ b/src/pudl_archiver/archivers/ferc/ferceqr.py
@@ -15,7 +15,7 @@ class FercEQRArchiver(AbstractDatasetArchiver):
     """FERC EQR archiver."""
 
     name = "ferceqr"
-    concurrency_limit = 5
+    concurrency_limit = 1
     directory_per_resource_chunk = True
     max_wait_time = 36000
 

--- a/src/pudl_archiver/utils.py
+++ b/src/pudl_archiver/utils.py
@@ -9,6 +9,18 @@ import aiohttp
 logger = logging.getLogger(f"catalystcoop.{__name__}")
 
 
+async def get_read(
+    session: aiohttp.ClientSession, args: list | None = None, kwargs: dict | None = None
+):
+    """Combine aiohttp get and read into one retry-able function."""
+    if args is None:
+        args = []
+    if kwargs is None:
+        kwargs = {}
+    async with session.get(*args, **kwargs) as response:
+        return await response.read()
+
+
 async def retry_async(
     async_func: Callable[..., Awaitable[Any]],
     args: list | None = None,

--- a/src/pudl_archiver/utils.py
+++ b/src/pudl_archiver/utils.py
@@ -10,13 +10,11 @@ logger = logging.getLogger(f"catalystcoop.{__name__}")
 
 
 async def get_read(
-    session: aiohttp.ClientSession, args: list | None = None, kwargs: dict | None = None
+    session: aiohttp.ClientSession,
+    *args,
+    **kwargs,
 ):
     """Combine aiohttp get and read into one retry-able function."""
-    if args is None:
-        args = []
-    if kwargs is None:
-        kwargs = {}
     async with session.get(*args, **kwargs) as response:
         return await response.read()
 

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -184,7 +184,7 @@ async def test_download_file(mocker, file_data):
     # Call method
     await archiver.download_file(url, file)
 
-    session_mock.get.assert_called_once_with(url)
+    session_mock.get.assert_called_once_with(url, timeout=300)
 
     assert file.getvalue() == file_data
 
@@ -194,7 +194,7 @@ async def test_download_file(mocker, file_data):
         file_path = Path(path) / "test"
         await archiver.download_file(url, file_path)
 
-        session_mock.get.assert_called_with(url)
+        session_mock.get.assert_called_with(url, timeout=300)
         file = file_path.open("rb")
         assert file.read() == file_data
 

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -168,13 +168,14 @@ async def test_download_file(mocker, file_data):
     # Initialize MockArchiver class
     archiver = MockArchiver(None)
 
-    session_mock = mocker.AsyncMock(name="session_mock")
-    archiver.session = session_mock
+    session_mock = mocker.MagicMock(name="session_mock")
 
     # Set return value
     response_mock = mocker.AsyncMock()
     response_mock.read = mocker.AsyncMock(return_value=file_data)
-    session_mock.get = mocker.AsyncMock(return_value=response_mock)
+    session_mock.get.return_value.__aenter__.return_value = response_mock
+
+    archiver.session = session_mock
 
     # Prepare args
     url = "https://www.fake.url.com"
@@ -193,7 +194,7 @@ async def test_download_file(mocker, file_data):
         file_path = Path(path) / "test"
         await archiver.download_file(url, file_path)
 
-        session_mock.get.assert_called_once_with(url)
+        session_mock.get.assert_called_with(url)
         file = file_path.open("rb")
         assert file.read() == file_data
 


### PR DESCRIPTION
Add minor robustness improvements that helped EQR archiving succeed. Combining the `GET` and `read` to one function when downloading files allows for more consistent retries when there are timeouts.