### PR TITLE
Xbrl taxonomy

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferc1.py
+++ b/src/pudl_archiver/archivers/ferc/ferc1.py
@@ -23,7 +23,20 @@ class Ferc1Archiver(AbstractDatasetArchiver):
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_1]
         for year, year_filings in filings.items():
             if self.valid_year(year):
+                if year > 2019:
+                    yield self.get_year_taxonomy_xbrl(year)
                 yield self.get_year_xbrl(year, year_filings)
+
+    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
+        """Download XBRL taxonomy from a single year."""
+        download_path = await xbrl.archive_taxonomy(
+            year, xbrl.FercForm.FORM_1, self.download_directory, self.session
+        )
+
+        return ResourceInfo(
+            local_path=download_path,
+            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
+        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc1.py
+++ b/src/pudl_archiver/archivers/ferc/ferc1.py
@@ -24,19 +24,13 @@ class Ferc1Archiver(AbstractDatasetArchiver):
         for year, year_filings in filings.items():
             if self.valid_year(year):
                 if year > 2019:
-                    yield self.get_year_taxonomy_xbrl(year)
+                    yield xbrl.archive_taxonomy(
+                        year,
+                        xbrl.FercForm.FORM_1,
+                        self.download_directory,
+                        self.session,
+                    )
                 yield self.get_year_xbrl(year, year_filings)
-
-    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
-        """Download XBRL taxonomy from a single year."""
-        download_path = await xbrl.archive_taxonomy(
-            year, xbrl.FercForm.FORM_1, self.download_directory, self.session
-        )
-
-        return ResourceInfo(
-            local_path=download_path,
-            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
-        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -34,7 +34,20 @@ class Ferc2Archiver(AbstractDatasetArchiver):
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
+            if year > 2019:
+                yield self.get_year_taxonomy_xbrl(year)
             yield self.get_year_xbrl(year, year_filings)
+
+    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
+        """Download XBRL taxonomy from a single year."""
+        download_path = await xbrl.archive_taxonomy(
+            year, xbrl.FercForm.FORM_2, self.download_directory, self.session
+        )
+
+        return ResourceInfo(
+            local_path=download_path,
+            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
+        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -35,19 +35,10 @@ class Ferc2Archiver(AbstractDatasetArchiver):
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield self.get_year_taxonomy_xbrl(year)
+                yield xbrl.archive_taxonomy(
+                    year, xbrl.FercForm.FORM_2, self.download_directory, self.session
+                )
             yield self.get_year_xbrl(year, year_filings)
-
-    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
-        """Download XBRL taxonomy from a single year."""
-        download_path = await xbrl.archive_taxonomy(
-            year, xbrl.FercForm.FORM_2, self.download_directory, self.session
-        )
-
-        return ResourceInfo(
-            local_path=download_path,
-            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
-        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -25,7 +25,20 @@ class Ferc6Archiver(AbstractDatasetArchiver):
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
+            if year > 2019:
+                yield self.get_year_taxonomy_xbrl(year)
             yield self.get_year_xbrl(year, year_filings)
+
+    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
+        """Download XBRL taxonomy from a single year."""
+        download_path = await xbrl.archive_taxonomy(
+            year, xbrl.FercForm.FORM_6, self.download_directory, self.session
+        )
+
+        return ResourceInfo(
+            local_path=download_path,
+            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
+        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -26,19 +26,10 @@ class Ferc6Archiver(AbstractDatasetArchiver):
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield self.get_year_taxonomy_xbrl(year)
+                yield xbrl.archive_taxonomy(
+                    year, xbrl.FercForm.FORM_6, self.download_directory, self.session
+                )
             yield self.get_year_xbrl(year, year_filings)
-
-    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
-        """Download XBRL taxonomy from a single year."""
-        download_path = await xbrl.archive_taxonomy(
-            year, xbrl.FercForm.FORM_6, self.download_directory, self.session
-        )
-
-        return ResourceInfo(
-            local_path=download_path,
-            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
-        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -25,7 +25,20 @@ class Ferc60Archiver(AbstractDatasetArchiver):
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
+            if year > 2019:
+                yield self.get_year_taxonomy_xbrl(year)
             yield self.get_year_xbrl(year, year_filings)
+
+    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
+        """Download XBRL taxonomy from a single year."""
+        download_path = await xbrl.archive_taxonomy(
+            year, xbrl.FercForm.FORM_60, self.download_directory, self.session
+        )
+
+        return ResourceInfo(
+            local_path=download_path,
+            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
+        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -26,19 +26,10 @@ class Ferc60Archiver(AbstractDatasetArchiver):
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield self.get_year_taxonomy_xbrl(year)
+                yield xbrl.archive_taxonomy(
+                    year, xbrl.FercForm.FORM_60, self.download_directory, self.session
+                )
             yield self.get_year_xbrl(year, year_filings)
-
-    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
-        """Download XBRL taxonomy from a single year."""
-        download_path = await xbrl.archive_taxonomy(
-            year, xbrl.FercForm.FORM_60, self.download_directory, self.session
-        )
-
-        return ResourceInfo(
-            local_path=download_path,
-            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
-        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -23,19 +23,10 @@ class Ferc714Archiver(AbstractDatasetArchiver):
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield self.get_year_taxonomy_xbrl(year)
+                yield xbrl.archive_taxonomy(
+                    year, xbrl.FercForm.FORM_714, self.download_directory, self.session
+                )
             yield self.get_year_xbrl(year, year_filings)
-
-    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
-        """Download XBRL taxonomy from a single year."""
-        download_path = await xbrl.archive_taxonomy(
-            year, xbrl.FercForm.FORM_714, self.download_directory, self.session
-        )
-
-        return ResourceInfo(
-            local_path=download_path,
-            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
-        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -22,7 +22,20 @@ class Ferc714Archiver(AbstractDatasetArchiver):
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
+            if year > 2019:
+                yield self.get_year_taxonomy_xbrl(year)
             yield self.get_year_xbrl(year, year_filings)
+
+    async def get_year_taxonomy_xbrl(self, year: int) -> tuple[Path, dict]:
+        """Download XBRL taxonomy from a single year."""
+        download_path = await xbrl.archive_taxonomy(
+            year, xbrl.FercForm.FORM_714, self.download_directory, self.session
+        )
+
+        return ResourceInfo(
+            local_path=download_path,
+            partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
+        )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -183,7 +183,10 @@ def index_available_entries() -> dict[FercForm, FormFilings]:
 
 
 async def archive_taxonomy(
-    form: FercForm, year: Year, archive: zipfile.ZipFile, session: aiohttp.ClientSession
+    year: Year,
+    form: FercForm,
+    output_dir: Path,
+    session: aiohttp.ClientSession,
 ):
     """Download taxonomy and archive all files that comprise the taxonomy.
 
@@ -197,9 +200,9 @@ async def archive_taxonomy(
     taxonomy.
 
     Args:
-        form: Ferc form.
         year: Year of taxonomy version.
-        archive: zipfile context manager.
+        form: Ferc form.
+        output_dir: Directory to save archived filings in.
         session: Async http client session.
     """
     # Get date used in entry point URL (first day of year)
@@ -223,21 +226,26 @@ async def archive_taxonomy(
         retry_on=(FileNotFoundError,),
     )
 
+    archive_path = output_dir / f"ferc{form_number}-xbrl-taxonomy-{year}.zip"
+
     # Loop through all files and save to appropriate location in archive
-    for url in taxonomy.urlDocs.keys():
-        url_parsed = urlparse(url)
+    with zipfile.ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
+        for url in taxonomy.urlDocs.keys():
+            url_parsed = urlparse(url)
 
-        # There are some generic XML/XBRL files in the taxonomy that should be skipped
-        if not url_parsed.netloc.endswith("ferc.gov"):
-            continue
+            # There are some generic XML/XBRL files in the taxonomy that should be skipped
+            if not url_parsed.netloc.endswith("ferc.gov"):
+                continue
 
-        # Download file
-        response = await retry_async(session.get, args=[url])
-        response_bytes = await retry_async(response.content.read)
-        path = Path(url_parsed.path).relative_to("/")
+            # Download file
+            response = await retry_async(session.get, args=[url])
+            response_bytes = await retry_async(response.content.read)
+            path = Path(url_parsed.path).relative_to("/")
 
-        with archive.open(str(path), "w") as f:
-            f.write(response_bytes)
+            with archive.open(str(path), "w") as f:
+                f.write(response_bytes)
+
+    return archive_path
 
 
 async def archive_year(
@@ -263,11 +271,6 @@ async def archive_year(
     archive_path = output_dir / f"ferc{form_number}-xbrl-{year}.zip"
 
     with zipfile.ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
-        # Archive taxonomy
-        # The first version of the taxonomy was released in 2020
-        if year > 2019:
-            await archive_taxonomy(form, year, archive, session)
-
         for filing in tqdm(filings, desc=f"FERC {form.value} {year} XBRL"):
             # Add filing metadata
             filing_name = f"{filing.title}{filing.ferc_period}"
@@ -285,7 +288,10 @@ async def archive_year(
                     f"Failed to download XBRL filing {filing.title} for form{form_number}-{year}: {e.message}"
                 )
             # Write to zipfile
-            with archive.open(f"{filing.entry_id}.xbrl", "w") as f:
+            filename = f"{filing.title}_form{filing.ferc_formname.as_int()}_{filing.ferc_period}_{round(filing.published_parsed.timestamp())}.xbrl".replace(
+                " ", "_"
+            )
+            with archive.open(filename, "w") as f:
                 f.write(response_bytes)
 
         # Save snapshot of RSS feed

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -20,6 +20,7 @@ from dateutil import rrule
 from pydantic import BaseModel, Field, HttpUrl, root_validator, validator
 from tqdm import tqdm
 
+from pudl_archiver.archivers.classes import ResourceInfo
 from pudl_archiver.utils import retry_async
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
@@ -245,7 +246,10 @@ async def archive_taxonomy(
             with archive.open(str(path), "w") as f:
                 f.write(response_bytes)
 
-    return archive_path
+    return ResourceInfo(
+        local_path=archive_path,
+        partitions={"year": year, "data_format": "XBRL_TAXONOMY"},
+    )
 
 
 async def archive_year(

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -281,12 +281,17 @@ async def archive_year(
 
             # Download filing
             try:
-                response = await retry_async(session.get, args=[filing.download_url])
+                response = await retry_async(
+                    session.get,
+                    args=[filing.download_url],
+                    kwargs={"raise_for_status": True},
+                )
                 response_bytes = await retry_async(response.content.read)
             except aiohttp.client_exceptions.ClientResponseError as e:
                 logger.warning(
                     f"Failed to download XBRL filing {filing.title} for form{form_number}-{year}: {e.message}"
                 )
+                continue
             # Write to zipfile
             filename = f"{filing.title}_form{filing.ferc_formname.as_int()}_{filing.ferc_period}_{round(filing.published_parsed.timestamp())}.xbrl".replace(
                 " ", "_"

--- a/tests/unit/ferc_archiver_test.py
+++ b/tests/unit/ferc_archiver_test.py
@@ -25,29 +25,54 @@ def make_testdata(module_test_spec_dict):
 
 valid_years_test_spec_dict = {
     "ferc1": [
-        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
-        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1},
-        {"years": [2003, 2004, 2005, 2021], "num_dbf": 4, "num_xbrl": 2},
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0, "num_taxonomy": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1, "num_taxonomy": 1},
+        {
+            "years": [2003, 2004, 2005, 2021],
+            "num_dbf": 4,
+            "num_xbrl": 2,
+            "num_taxonomy": 1,
+        },
     ],
     "ferc2": [
-        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
-        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1},
-        {"years": [2003, 2004, 2005, 2021], "num_dbf": 4, "num_xbrl": 2},
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0, "num_taxonomy": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1, "num_taxonomy": 1},
+        {
+            "years": [2003, 2004, 2005, 2021],
+            "num_dbf": 4,
+            "num_xbrl": 2,
+            "num_taxonomy": 1,
+        },
     ],
     "ferc6": [
-        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
-        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1},
-        {"years": [2003, 2004, 2005, 2021], "num_dbf": 4, "num_xbrl": 2},
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0, "num_taxonomy": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 1, "num_xbrl": 1, "num_taxonomy": 1},
+        {
+            "years": [2003, 2004, 2005, 2021],
+            "num_dbf": 4,
+            "num_xbrl": 2,
+            "num_taxonomy": 1,
+        },
     ],
     "ferc60": [
-        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
-        {"years": [2021, 2022, 2023], "num_dbf": 0, "num_xbrl": 1},
-        {"years": [2004, 2005, 2006, 2007, 2021], "num_dbf": 2, "num_xbrl": 2},
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0, "num_taxonomy": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 0, "num_xbrl": 1, "num_taxonomy": 1},
+        {
+            "years": [2004, 2005, 2006, 2007, 2021],
+            "num_dbf": 2,
+            "num_xbrl": 2,
+            "num_taxonomy": 1,
+        },
     ],
     "ferc714": [
-        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0},
-        {"years": [2021, 2022, 2023], "num_dbf": 0, "num_xbrl": 1},
-        {"years": [2004, 2005, 2006, 2007, 2021], "num_dbf": 0, "num_xbrl": 2},
+        {"years": [1848, 2349], "num_dbf": 0, "num_xbrl": 0, "num_taxonomy": 0},
+        {"years": [2021, 2022, 2023], "num_dbf": 0, "num_xbrl": 1, "num_taxonomy": 1},
+        {
+            "years": [2004, 2005, 2006, 2007, 2021],
+            "num_dbf": 0,
+            "num_xbrl": 2,
+            "num_taxonomy": 1,
+        },
     ],
 }
 
@@ -61,6 +86,7 @@ async def test_valid_years(module_name, test_spec, mocker):
     only_years = test_spec["years"]
     num_dbf = test_spec["num_dbf"]
     num_xbrl = test_spec["num_xbrl"]
+    num_taxonomy = test_spec["num_taxonomy"]
 
     mocker.patch(
         f"pudl_archiver.archivers.ferc.{module_name}.xbrl.index_available_entries",
@@ -72,5 +98,7 @@ async def test_valid_years(module_name, test_spec, mocker):
     # don't await these, just check to make sure they have right intention
     dbfs = [r for r in resources if r.__name__ == "get_year_dbf"]
     xbrls = [r for r in resources if r.__name__ == "get_year_xbrl"]
+    taxonomies = [r for r in resources if r.__name__ == "archive_taxonomy"]
     assert len(dbfs) == num_dbf
     assert len(xbrls) == num_xbrl
+    assert len(taxonomies) == num_taxonomy


### PR DESCRIPTION
This PR adjusts the layout of FERC XBRL archives. It moves the taxonomies to be their own resource instead of bundled with a year of filings.