### PR TITLE
When making a new dataset, assert keywords exist

### DIFF
--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -190,6 +190,10 @@ class DepositionOrchestrator:
             https://developers.zenodo.org/?python#depositions
         """
         metadata = DepositionMetadata.from_data_source(data_source_id)
+        if not metadata.keywords:
+            raise AssertionError(
+                "New dataset is missing keywords and cannot be archived."
+            )
         return await self.depositor.create_deposition(metadata)
 
     async def run(self) -> RunSummary | Unchanged:


### PR DESCRIPTION
Current archiving infrastructure allows keywords for Zenodo datasets to be null. This poses a problem when using the datastore. This PR adds an assertion that mandates keywords for new archives to prevent this issue. You can test it by running it on MSHA, PHMSA, or EIA Water data with a `--initialize` flag.