### PR TITLE
Update to depending on PUDL development branch.

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   archive-run:
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         dataset:
@@ -40,20 +43,18 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up conda environment for testing
-        uses: conda-incubator/setup-miniconda@v2.2.0
+      - name: Install Conda environment using mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          python-version: "3.10"
-          activate-environment: pudl-cataloger
           environment-file: environment.yml
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
 
-      - shell: bash -l {0}
+      - name: Log the conda environment
         run: |
           conda info
           conda list
@@ -70,7 +71,7 @@ jobs:
           # ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
           # ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         run: |
-          conda run -n pudl-cataloger pudl_archiver --sandbox --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
+          pudl_archiver --sandbox --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -14,18 +14,17 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up conda environment for testing
-        uses: conda-incubator/setup-miniconda@v2.2.0
+      - name: Install Conda environment using mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          python-version: "3.10"
-          activate-environment: pudl-cataloger
           environment-file: environment.yml
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
+
       - shell: bash -l {0}
         run: |
           conda info
@@ -43,7 +42,7 @@ jobs:
           conda run -n pudl-cataloger tox
 
       - name: Upload test coverage report to CodeCov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3
 
   ci-notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +28,7 @@ jobs:
             - defaults
             channel_priority: strict
 
-      - shell: bash -l {0}
+      - name: Log conda environnment information
         run: |
           conda info
           conda list

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -39,7 +39,7 @@ jobs:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
         run: |
-          conda run -n pudl-cataloger tox
+          tox
 
       - name: Upload test coverage report to CodeCov
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ commit.txt
 coverage.xml
 .env_tox
 .env
+**/*~

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,8 @@ channels:
 dependencies:
   # Used to set up the environment
   - pip>=21,<24
-  - python>=3.10,<3.11
-  - setuptools<66,>=61.0
+  - python>=3.11,<3.12
+  - setuptools<69,>=66
   # fiona is a transitive dependency which needs GDAL. so we install with conda
   # TODO: we shouldn't have to install all this geo stuff, so once we break the
   # dependency on `pudl` we should remove this too.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,11 @@
 name = "pudl_archiver"
 version = "0.2.0"
 authors = [{name = "PUDL", email = "pudl@catalyst.coop"}]
-requires-python = ">=3.10,<3.11"
+requires-python = ">=3.11,<3.12"
 
 dependencies = [
-    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git@pre-dagster",
-    "coloredlogs~=15.0",
+    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git@dev",
+    "coloredlogs>=14",
     "feedparser>=6.0",
     "tqdm>=4.64",
     "python-dotenv~=1.0.0",
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 
@@ -73,7 +73,7 @@ pudl_archiver = "pudl_archiver.cli:main"
 
 [build-system]
 requires = [
-    "setuptools<66,>=61.0",
+    "setuptools<69,>=66",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tests/unit/zenodo_entities_test.py
+++ b/tests/unit/zenodo_entities_test.py
@@ -6,4 +6,4 @@ def test_depo_metadata_from_data_source():
     """Test creating DepositionMetadata from datasource."""
     depo_metadata = DepositionMetadata.from_data_source("ferc1")
 
-    assert depo_metadata.title == "PUDL Raw FERC Form 1"
+    assert depo_metadata.title.startswith("PUDL Raw FERC Form 1")


### PR DESCRIPTION
While trying to debug a dependency update CI failure, I noticed that we still had this repo pinned to depending on the `catalystcoop.pudl@pre-dagster` branch 😲 

So I did some updates:

* Point PUDL dependency at `catalsytcoop.pudl@dev`
* Use Python 3.11
* Switch to using the newer and maintained `mamba-org/setup-micromamba` action both in the `tox-pytest` and `run-archiver` workflows.
* Updated one test that was expecting an old FERC Form 1 title and not getting it.