### PR TITLE
Icebox: Migrate to new Zenodo InvenioRDM API

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -9,43 +9,43 @@ eia860:
   sandbox_doi: 10.5281/zenodo.123456
 eia860m:
   production_doi: 10.5281/zenodo.4281336
-  sandbox_doi: 10.5281/zenodo.8188017
+  sandbox_doi: 10.5281/zenodo.4281336
 eia861:
   production_doi: 10.5281/zenodo.4127028
-  sandbox_doi: 10.5281/zenodo.8231268
+  sandbox_doi: 10.5281/zenodo.4127028
 eia923:
   production_doi: 10.5281/zenodo.4127039
-  sandbox_doi: 10.5281/zenodo.8172818
+  sandbox_doi: 10.5281/zenodo.4127039
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366
-  sandbox_doi: 10.5281/zenodo.7682482
+  sandbox_doi: 10.5281/zenodo.7067366
 eiawater:
   production_doi: 10.5281/zenodo.7683135
   sandbox_doi: 10.5281/zenodo.123456
 epacamd_eia:
   production_doi: 10.5281/zenodo.6633769
-  sandbox_doi: 10.5281/zenodo.7900974
+  sandbox_doi: 10.5281/zenodo.6633769
 epacems:
   production_doi: 10.5281/zenodo.4127054
   sandbox_doi: 10.5281/zenodo.123456
 ferc1:
   production_doi: 10.5281/zenodo.4127043
-  sandbox_doi: 10.5281/zenodo.8234738
+  sandbox_doi: 10.5281/zenodo.4127043
 ferc2:
   production_doi: 10.5281/zenodo.5879542
-  sandbox_doi: 10.5281/zenodo.8006881
+  sandbox_doi: 10.5281/zenodo.5879542
 ferc6:
   production_doi: 10.5281/zenodo.7126395
-  sandbox_doi: 10.5281/zenodo.7130141
+  sandbox_doi: 10.5281/zenodo.7126395
 ferc60:
   production_doi: 10.5281/zenodo.7126434
   sandbox_doi: 10.5281/zenodo.123456
 ferc714:
   production_doi: 10.5281/zenodo.4127100
-  sandbox_doi: 10.5281/zenodo.7139875
+  sandbox_doi: 10.5281/zenodo.4127100
 mshamines:
   production_doi: 10.5281/zenodo.7683517
-  sandbox_doi: 10.5281/zenodo.7683518
+  sandbox_doi: 10.5281/zenodo.7683517
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
-  sandbox_doi: 10.5281/zenodo.7683352
+  sandbox_doi: 10.5281/zenodo.7683351

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -9,43 +9,43 @@ eia860:
   sandbox_doi: 10.5281/zenodo.123456
 eia860m:
   production_doi: 10.5281/zenodo.4281336
-  sandbox_doi: 10.5281/zenodo.4281336
+  sandbox_doi: 10.5281/zenodo.8188017
 eia861:
   production_doi: 10.5281/zenodo.4127028
-  sandbox_doi: 10.5281/zenodo.4127028
+  sandbox_doi: 10.5281/zenodo.8231268
 eia923:
   production_doi: 10.5281/zenodo.4127039
-  sandbox_doi: 10.5281/zenodo.4127039
+  sandbox_doi: 10.5281/zenodo.8172818
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366
-  sandbox_doi: 10.5281/zenodo.7067366
+  sandbox_doi: 10.5281/zenodo.7682482
 eiawater:
   production_doi: 10.5281/zenodo.7683135
   sandbox_doi: 10.5281/zenodo.123456
 epacamd_eia:
   production_doi: 10.5281/zenodo.6633769
-  sandbox_doi: 10.5281/zenodo.6633769
+  sandbox_doi: 10.5281/zenodo.7900974
 epacems:
   production_doi: 10.5281/zenodo.4127054
   sandbox_doi: 10.5281/zenodo.123456
 ferc1:
   production_doi: 10.5281/zenodo.4127043
-  sandbox_doi: 10.5281/zenodo.4127043
+  sandbox_doi: 10.5281/zenodo.8234738
 ferc2:
   production_doi: 10.5281/zenodo.5879542
-  sandbox_doi: 10.5281/zenodo.5879542
+  sandbox_doi: 10.5281/zenodo.8006881
 ferc6:
   production_doi: 10.5281/zenodo.7126395
-  sandbox_doi: 10.5281/zenodo.7126395
+  sandbox_doi: 10.5281/zenodo.7130141
 ferc60:
   production_doi: 10.5281/zenodo.7126434
   sandbox_doi: 10.5281/zenodo.123456
 ferc714:
   production_doi: 10.5281/zenodo.4127100
-  sandbox_doi: 10.5281/zenodo.4127100
+  sandbox_doi: 10.5281/zenodo.7139875
 mshamines:
   production_doi: 10.5281/zenodo.7683517
-  sandbox_doi: 10.5281/zenodo.7683517
+  sandbox_doi: 10.5281/zenodo.7683518
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
-  sandbox_doi: 10.5281/zenodo.7683351
+  sandbox_doi: 10.5281/zenodo.7683352

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -1,51 +1,51 @@
 censusdp1tract:
   production_doi: 10.5281/zenodo.4127048
-  sandbox_doi: 10.5072/zenodo.1151526
+  sandbox_doi: 10.5281/zenodo.123456
 eia176:
   production_doi: 10.5281/zenodo.7682357
-  sandbox_doi: 10.5072/zenodo.1168394
+  sandbox_doi: 10.5281/zenodo.123456
 eia860:
   production_doi: 10.5281/zenodo.4127026
-  sandbox_doi: 10.5072/zenodo.672209
+  sandbox_doi: 10.5281/zenodo.123456
 eia860m:
   production_doi: 10.5281/zenodo.4281336
-  sandbox_doi: 10.5072/zenodo.692654
+  sandbox_doi: 10.5281/zenodo.8188017
 eia861:
   production_doi: 10.5281/zenodo.4127028
-  sandbox_doi: 10.5072/zenodo.672198
+  sandbox_doi: 10.5281/zenodo.8231268
 eia923:
   production_doi: 10.5281/zenodo.4127039
-  sandbox_doi: 10.5072/zenodo.672220
+  sandbox_doi: 10.5281/zenodo.8172818
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366
-  sandbox_doi: 10.5072/zenodo.1103571
+  sandbox_doi: 10.5281/zenodo.7682482
 eiawater:
   production_doi: 10.5281/zenodo.7683135
-  sandbox_doi: 10.5072/zenodo.1161347
+  sandbox_doi: 10.5281/zenodo.123456
 epacamd_eia:
   production_doi: 10.5281/zenodo.6633769
-  sandbox_doi: 10.5072/zenodo.1072000
+  sandbox_doi: 10.5281/zenodo.7900974
 epacems:
   production_doi: 10.5281/zenodo.4127054
-  sandbox_doi: 10.5072/zenodo.1228518
+  sandbox_doi: 10.5281/zenodo.123456
 ferc1:
   production_doi: 10.5281/zenodo.4127043
-  sandbox_doi: 10.5072/zenodo.1114564
+  sandbox_doi: 10.5281/zenodo.8234738
 ferc2:
   production_doi: 10.5281/zenodo.5879542
-  sandbox_doi: 10.5072/zenodo.1096046
+  sandbox_doi: 10.5281/zenodo.8006881
 ferc6:
   production_doi: 10.5281/zenodo.7126395
-  sandbox_doi: 10.5072/zenodo.1114637
+  sandbox_doi: 10.5281/zenodo.7130141
 ferc60:
   production_doi: 10.5281/zenodo.7126434
-  sandbox_doi: 10.5072/zenodo.1114668
+  sandbox_doi: 10.5281/zenodo.123456
 ferc714:
   production_doi: 10.5281/zenodo.4127100
-  sandbox_doi: 10.5072/zenodo.1114673
+  sandbox_doi: 10.5281/zenodo.7139875
 mshamines:
   production_doi: 10.5281/zenodo.7683517
-  sandbox_doi: 10.5072/zenodo.1158828
+  sandbox_doi: 10.5281/zenodo.7683518
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
-  sandbox_doi: 10.5072/zenodo.1161321
+  sandbox_doi: 10.5281/zenodo.7683352

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -9,43 +9,43 @@ eia860:
   sandbox_doi: 10.5281/zenodo.123456
 eia860m:
   production_doi: 10.5281/zenodo.4281336
-  sandbox_doi: 10.5281/zenodo.8188017
+  sandbox_doi: 10.5281/zenodo.8188016
 eia861:
   production_doi: 10.5281/zenodo.4127028
-  sandbox_doi: 10.5281/zenodo.8231268
+  sandbox_doi: 10.5281/zenodo.823125
 eia923:
   production_doi: 10.5281/zenodo.4127039
-  sandbox_doi: 10.5281/zenodo.8172818
+  sandbox_doi: 10.5281/zenodo.8172817
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366
-  sandbox_doi: 10.5281/zenodo.7682482
+  sandbox_doi: 10.5281/zenodo.7682481
 eiawater:
   production_doi: 10.5281/zenodo.7683135
   sandbox_doi: 10.5281/zenodo.123456
 epacamd_eia:
   production_doi: 10.5281/zenodo.6633769
-  sandbox_doi: 10.5281/zenodo.7900974
+  sandbox_doi: 10.5281/zenodo.7900973
 epacems:
   production_doi: 10.5281/zenodo.4127054
   sandbox_doi: 10.5281/zenodo.123456
 ferc1:
   production_doi: 10.5281/zenodo.4127043
-  sandbox_doi: 10.5281/zenodo.8234738
+  sandbox_doi: 10.5281/zenodo.8234737
 ferc2:
   production_doi: 10.5281/zenodo.5879542
-  sandbox_doi: 10.5281/zenodo.8006881
+  sandbox_doi: 10.5281/zenodo.8006880
 ferc6:
   production_doi: 10.5281/zenodo.7126395
-  sandbox_doi: 10.5281/zenodo.7130141
+  sandbox_doi: 10.5281/zenodo.7130140
 ferc60:
   production_doi: 10.5281/zenodo.7126434
   sandbox_doi: 10.5281/zenodo.123456
 ferc714:
   production_doi: 10.5281/zenodo.4127100
-  sandbox_doi: 10.5281/zenodo.7139875
+  sandbox_doi: 10.5281/zenodo.7139874
 mshamines:
   production_doi: 10.5281/zenodo.7683517
-  sandbox_doi: 10.5281/zenodo.7683518
+  sandbox_doi: 10.5281/zenodo.7683517
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
-  sandbox_doi: 10.5281/zenodo.7683352
+  sandbox_doi: 10.5281/zenodo.7683351

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -18,7 +18,7 @@ eia923:
   sandbox_doi: 10.5281/zenodo.8172817
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366
-  sandbox_doi: 10.5281/zenodo.7682481
+  sandbox_doi: 10.5281/zenodo.10003268
 eiawater:
   production_doi: 10.5281/zenodo.7683135
   sandbox_doi: 10.5281/zenodo.123456

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -42,6 +42,7 @@ async def archive_datasets(
     summary_file: str | None = None,
     download_dir: str | None = None,
     auto_publish: bool = False,
+    refresh_metadata: bool = False,
 ):
     """A CLI for the PUDL Zenodo Storage system."""
     if sandbox:
@@ -88,6 +89,7 @@ async def archive_datasets(
                 dry_run=dry_run,
                 sandbox=sandbox,
                 auto_publish=auto_publish,
+                refresh_metadata=refresh_metadata,
             )
 
             tasks.append(orchestrator.run())

--- a/src/pudl_archiver/archivers/eia860.py
+++ b/src/pudl_archiver/archivers/eia860.py
@@ -20,9 +20,9 @@ class Eia860Archiver(AbstractDatasetArchiver):
         """Download EIA-860 resources."""
         link_pattern = re.compile(r"eia860(\d{4})(ER)*.zip")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            year = link_pattern.search(link).group(1)
+            year = int(link_pattern.search(link).group(1))
             if self.valid_year(year):
-                yield self.get_year_resource(link, link_pattern.search(link))
+                yield self.get_year_resource(link, year)
 
     async def get_year_resource(self, link: str, year: int) -> tuple[Path, dict]:
         """Download zip file."""

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -65,6 +65,11 @@ def parse_main():
         help="Directory to download files to. Use tmpdir if not specified.",
         default=None,
     )
+    parser.add_argument(
+        "--refresh-metadata",
+        action="store_true",
+        help="Regenerate metadata from PUDL data source rather than existing archived metadata.",
+    )
     return parser.parse_args()
 
 

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -357,7 +357,7 @@ class ZenodoDepositor:
             headers=self.auth_write,
         )
 
-    async def publish_deposition(self, deposition: Deposition) -> Deposition:
+    async def publish_deposition(self, deposition: Deposition) -> DepositionVersion:
         """Publish a deposition.
 
         Needs to have at least one file, and needs to not already be published.
@@ -373,7 +373,8 @@ class ZenodoDepositor:
         response = await self.request(
             "POST", url, log_label="Publishing deposition", headers=headers
         )
-        return Deposition(**response)
+        logger.info(response)
+        return DepositionVersion(**response)
 
     async def delete_deposition(self, deposition) -> None:
         """Delete an un-submitted deposition.

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -127,14 +127,19 @@ class ZenodoDepositor:
             "Content-Type": "application/json",
         } | self.auth_write
 
-        payload = {
-            "access": {"record": "public", "files": "public"},  # TO DO: don't hardcode?
-            "files": json.dumps({"enabled": True}),
-            "metadata": metadata.dict(
-                by_alias=True,
-                exclude={"publication_date", "doi", "prereserve_doi"},
-            ),
-        }
+        payload = json.dumps(
+            {
+                "access": {
+                    "record": "public",
+                    "files": "public",
+                },  # TO DO: don't hardcode?
+                "files": {"enabled": True},
+                "metadata": metadata.dict(
+                    by_alias=True,
+                    exclude={"publication_date", "doi", "prereserve_doi"},
+                ),
+            }
+        )
         logger.info(payload)
         response = await self.request(
             "POST", url, "Create new deposition", json=payload, headers=headers
@@ -170,6 +175,7 @@ class ZenodoDepositor:
             params=params,
             headers=self.auth_write,
         )
+        logger.info(response)
         if response["hits"]["total"] > 1:
             logger.info(
                 f"{concept_doi} points at multiple records: {[r['id'] for r in response['hits']['hits']]}"

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -342,7 +342,6 @@ class ZenodoDepositor:
             log_label="Creating new version.",
             headers=headers,
         )
-        logger.info(response)
         return DepositionVersion(**response)
 
     async def link_previous_files(
@@ -374,7 +373,6 @@ class ZenodoDepositor:
         response = await self.request(
             "POST", url, log_label="Publishing deposition", headers=headers
         )
-        logger.info(response)
         return Deposition(**response)
 
     async def delete_deposition(self, deposition) -> None:
@@ -496,7 +494,7 @@ class ZenodoDepositor:
             "PUT",
             file_links["content"],
             log_label=f"Uploading {target} data",
-            data={"content": data},
+            data=data,
             headers=headers,
         )
 

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -128,12 +128,14 @@ class ZenodoDepositor:
         } | self.auth_write
 
         payload = {
+            "access": {"record": "public", "files": "public"},  # TO DO: don't hardcode?
+            "files": json.dumps({"enabled": True}),
             "metadata": metadata.dict(
                 by_alias=True,
                 exclude={"publication_date", "doi", "prereserve_doi"},
-            )
+            ),
         }
-
+        logger.info(payload)
         response = await self.request(
             "POST", url, "Create new deposition", json=payload, headers=headers
         )
@@ -275,8 +277,6 @@ class ZenodoDepositor:
             data=data,
             headers=headers,
         )
-
-        logger.info(response)
         return Deposition(**response)
 
     async def get_new_deposition_version(self, deposition: Deposition):

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -226,40 +226,13 @@ class ZenodoDepositor:
         # If files already in new deposition, remove.
         if len(new_deposition.files) > 0:
             await self.delete_deposition(new_deposition)  # DEBUG ME!
-            # new_deposition = await self.get_new_deposition_version(deposition) # Debug: Something isn't working here!
+            new_deposition = await self.get_new_deposition_version(
+                deposition
+            )  # Debug: Something isn't working here!
 
         # Link files from previous deposition.
         await self.link_previous_files(new_deposition)
 
-        # new_deposition_url = old_deposition.links.latest_draft
-
-        # source_metadata = old_deposition.metadata.dict(by_alias=True)
-        # metadata = {}
-        # for key, val in source_metadata.items():
-        #     if key not in ["doi", "prereserve_doi", "publication_date"]:
-        #         metadata[key] = val
-
-        # previous = semantic_version.Version(source_metadata["version"])
-        # version_info = previous.next_major()
-
-        # metadata["version"] = str(version_info)
-
-        # # Update metadata of new deposition with new version info
-        # data = json.dumps({"metadata": metadata})
-
-        # # Get url to newest deposition
-        # new_deposition_url = old_deposition.links.latest_draft
-        # headers = {
-        #     "Content-Type": "application/json",
-        # } | self.auth_write
-
-        # response = await self.request(
-        #     "PUT",
-        #     new_deposition_url,
-        #     log_label=f"Updating version number from {previous} ({old_deposition.id_}) to {version_info}",
-        #     data=data,
-        #     headers=headers,
-        # )
         return new_deposition
 
     async def get_new_deposition_version(self, deposition: Deposition):
@@ -268,7 +241,7 @@ class ZenodoDepositor:
         response = await self.request(
             "POST",
             url,
-            log_label="Creating new version",
+            log_label="Creating new version.",
             headers=self.auth_write,
         )
         return Deposition(**response)
@@ -280,7 +253,7 @@ class ZenodoDepositor:
         await self.request(
             "POST",
             url,
-            log_label="Linking files from previous deposition",
+            log_label="Linking files from previous deposition.",
             headers=self.auth_write,
         )
 
@@ -382,14 +355,16 @@ class ZenodoDepositor:
         headers = {
             "Content-Type": "application/json",
         } | self.auth_write
-        params = {"key": target}
-        return await self.request(
+        params = {"key": target}  # NOT WORKING CURRENTLY?
+        response = await self.request(
             "POST",
             url,
             log_label=f"Starting upload of {target}",
             headers=headers,
             params=params,
         )
+        logger.info(response)
+        return response
 
     async def upload_data_to_file(
         self, deposition: Deposition, target: str, data: BinaryIO

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -50,10 +50,9 @@ class Resource(BaseModel):
         """
         filename = Path(file.key)
         mt = MEDIA_TYPES[filename.suffix[1:]]
+        # Remove /api, /draft from link to get stable path
         if "/api" or "/draft" in file.links.self:
-            stable_path = file.links.self.replace("/api", "").replace(
-                "/draft", ""
-            )  # Remove /api from link to get stable path
+            stable_path = file.links.self.replace("/api", "").replace("/draft", "")
         else:
             stable_path = file.links.self
 
@@ -65,7 +64,7 @@ class Resource(BaseModel):
             mediatype=mt,
             parts=parts,
             bytes=file.size,
-            hash=file.checksum,
+            hash=file.checksum.replace("md5:", ""),  # Drop md5 hash prefix
             format=filename.suffix,
         )
 

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -50,9 +50,13 @@ class Resource(BaseModel):
         """
         filename = Path(file.key)
         mt = MEDIA_TYPES[filename.suffix[1:]]
-        # Remove /api, /draft from link to get stable path
-        if "/api" or "/draft" in file.links.self:
-            stable_path = file.links.self.replace("/api", "").replace("/draft", "")
+        # Remove /api, /draft, /content from link to get stable path
+        if "/api" or "/draft" or "/content" in file.links.self:
+            stable_path = (
+                file.links.self.replace("/api", "")
+                .replace("/draft", "")
+                .replace("/content", "")
+            )
         else:
             stable_path = file.links.self
 

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -50,11 +50,17 @@ class Resource(BaseModel):
         """
         filename = Path(file.filename)
         mt = MEDIA_TYPES[filename.suffix[1:]]
+        if "/api" in file.links.self:
+            stable_path = file.links.self.replace(
+                "/api", ""
+            )  # Remove /api from link to get stable path
+        else:
+            stable_path = file.links.self
 
         return cls(
             name=file.filename,
-            path=file.links.download,
-            remote_url=file.links.download,
+            path=stable_path,
+            remote_url=stable_path,
             title=filename.name,
             mediatype=mt,
             parts=parts,

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -48,23 +48,23 @@ class Resource(BaseModel):
             file: Deposition file metadata returned by Zenodo api.
             parts: Working partitions of current resource.
         """
-        filename = Path(file.filename)
+        filename = Path(file.key)
         mt = MEDIA_TYPES[filename.suffix[1:]]
-        if "/api" in file.links.self:
-            stable_path = file.links.self.replace(
-                "/api", ""
+        if "/api" or "/draft" in file.links.self:
+            stable_path = file.links.self.replace("/api", "").replace(
+                "/draft", ""
             )  # Remove /api from link to get stable path
         else:
             stable_path = file.links.self
 
         return cls(
-            name=file.filename,
+            name=file.key,
             path=stable_path,
             remote_url=stable_path,
             title=filename.name,
             mediatype=mt,
             parts=parts,
-            bytes=file.filesize,
+            bytes=file.size,
             hash=file.checksum,
             format=filename.suffix,
         )
@@ -114,7 +114,7 @@ class DataPackage(BaseModel):
             sources=[{"title": data_source.title, "path": data_source.path}],
             licenses=[data_source.license_raw],
             resources=[
-                Resource.from_file(file, resources[file.filename].partitions)
+                Resource.from_file(file, resources[file.key].partitions)
                 for file in files
             ],
             contributors=[CONTRIBUTORS["catalyst-cooperative"]],

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -97,6 +97,7 @@ class DepositionOrchestrator:
         dry_run: bool = True,
         sandbox: bool = True,
         auto_publish: bool = False,
+        refresh_metadata: bool = False,
     ):
         """Prepare the ZenodoStorage interface.
 
@@ -124,6 +125,7 @@ class DepositionOrchestrator:
         self.publish_key = publish_key
 
         self.auto_publish = auto_publish
+        self.refresh_metadata = refresh_metadata
 
         self.depositor = ZenodoDepositor(upload_key, publish_key, session, self.sandbox)
         self.downloader = downloader
@@ -155,7 +157,10 @@ class DepositionOrchestrator:
 
             self.deposition = await self.depositor.get_deposition(doi)
         self.new_deposition = await self.depositor.get_new_version(
-            self.deposition, clobber=not self.create_new
+            self.deposition,
+            clobber=not self.create_new,
+            data_source_id=self.data_source_id,
+            refresh_metadata=self.refresh_metadata,
         )
 
         # TODO (daz): stop using self.deposition_files, use the files lists on the depositions
@@ -343,8 +348,8 @@ class DepositionOrchestrator:
         # concept DOI from the datapackage so we make it manually.
         published_deposition["conceptdoi"] = re.sub(
             r"\d{6,7}$",
-            published_deposition["conceptrecid"],
-            published_deposition["doi"],
+            published_deposition.conceptrecid,
+            published_deposition.doi,
         )
         if self.sandbox:
             sandbox_doi = published_deposition.conceptdoi
@@ -395,6 +400,7 @@ class DepositionOrchestrator:
                 parse_json=False,
                 headers=self.depositor.auth_write,
             )
+            logger.info(response.content)
             response_bytes = await retry_async(response.read)
             old_datapackage = DataPackage.parse_raw(response_bytes)
 

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -239,7 +239,9 @@ class DepositionOrchestrator:
             for name in files_to_delete
         ]
 
-        self.new_deposition = await self.depositor.get_record(self.new_deposition.id_)
+        self.new_deposition = await self.depositor.get_draft_record(
+            self.new_deposition.id_
+        )
         if changed:
             # If there are any changes detected update datapackage and publish
             new_datapackage, old_datapackage = await self._update_datapackage(resources)
@@ -259,7 +261,7 @@ class DepositionOrchestrator:
             else:
                 logger.info("Skipping publishing deposition to allow manual review.")
                 logger.info(
-                    f"Review new deposition at {self.new_deposition.links.html}"
+                    f"Review new deposition at {self.new_deposition.links.self_html}"
                 )
             return run_summary
         else:

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -20,7 +20,6 @@ from pudl_archiver.zenodo.entities import (
     DepositionFile,
     DepositionMetadata,
     Doi,
-    SandboxDoi,
 )
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
@@ -69,7 +68,7 @@ class DatasetSettings(BaseModel):
     """Simple model to validate doi's in settings."""
 
     production_doi: Doi | None = None
-    sandbox_doi: SandboxDoi | None = None
+    sandbox_doi: Doi | None = None
 
 
 def _compute_md5(file_path: Path) -> str:

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -421,7 +421,7 @@ class DepositionOrchestrator:
         )
 
         datapackage_json = io.BytesIO(
-            bytes(datapackage.json(by_alias=True), encoding="utf-8")
+            bytes(datapackage.json(indent=4, by_alias=True), encoding="utf-8")
         )
 
         await self._apply_change(

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -284,13 +284,12 @@ class DepositionOrchestrator:
             action = _DepositionAction.CREATE
         else:
             file_info = self.deposition_files[name]
-
+            file_info.checksum = file_info.checksum.replace("md5:", "")  # Remove prefix
             # If file is not exact match for existing file, update with new file
-            if not (
-                local_md5 := _compute_md5(resource.local_path)
-            ) == file_info.checksum.replace(
-                "md5:", ""
-            ):  # Remove prefix
+            if (
+                not (local_md5 := _compute_md5(resource.local_path))
+                == file_info.checksum
+            ):
                 logger.info(
                     f"Updating {name}: local hash {local_md5} vs. remote {file_info.checksum}"
                 )
@@ -400,7 +399,7 @@ class DepositionOrchestrator:
                 parse_json=False,
                 headers=self.depositor.auth_write,
             )
-            logger.info(response.content)
+            logger.info
             response_bytes = await retry_async(response.read)
             old_datapackage = DataPackage.parse_raw(response_bytes)
 

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -281,10 +281,11 @@ class DepositionOrchestrator:
             file_info = self.deposition_files[name]
 
             # If file is not exact match for existing file, update with new file
-            if (
-                not (local_md5 := _compute_md5(resource.local_path))
-                == file_info.checksum
-            ):
+            if not (
+                local_md5 := _compute_md5(resource.local_path)
+            ) == file_info.checksum.replace(
+                "md5:", ""
+            ):  # Remove prefix
                 logger.info(
                     f"Updating {name}: local hash {local_md5} vs. remote {file_info.checksum}"
                 )

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -15,15 +15,9 @@ logger = logging.getLogger(f"catalystcoop.{__name__}")
 
 
 class Doi(ConstrainedStr):
-    """The DOI format for production Zenodo."""
+    """The DOI format for production and sandbox Zenodo."""
 
     regex = re.compile(r"10\.5281/zenodo\.\d{6,7}")
-
-
-class SandboxDoi(ConstrainedStr):
-    """The DOI format for sandbox Zenodo."""
-
-    regex = re.compile(r"10\.5072/zenodo\.\d{6,7}")
 
 
 PUDL_DESCRIPTION = """
@@ -166,7 +160,6 @@ class DepositionMetadata(BaseModel):
     See https://developers.zenodo.org/#representation.
     """
 
-    upload_type: str = "dataset"
     publication_date: datetime.date = None
     language: str = "eng"
     title: str
@@ -174,8 +167,8 @@ class DepositionMetadata(BaseModel):
     communities: list[dict] | None = None
     description: str
     access_right: str = "open"
-    license_: License | None = None
-    doi: Doi | SandboxDoi | None = None
+    license_: License | None = Field(alias="license")
+    doi: Doi | None = None
     prereserve_doi: dict | bool = False
     keywords: list[str] | None = None
     version: str | None = None
@@ -289,7 +282,7 @@ class Deposition(BaseModel):
     See https://developers.zenodo.org/#depositions.
     """
 
-    conceptdoi: Doi | SandboxDoi | None = None
+    conceptdoi: Doi
     conceptrecid: str
     created: datetime.datetime
     files: list[DepositionFile] = []
@@ -300,6 +293,7 @@ class Deposition(BaseModel):
     owners: list[dict] = []
     recid: int
     record_url: AnyHttpUrl | None = None
+    resource_type: dict[str, str] = {"id": "dataset"}
     state: Literal["inprogress", "done", "error", "submitted", "unsubmitted"]
     submitted: bool
     title: str

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -209,7 +209,7 @@ class DepositionMetadata(BaseModel):
     resource_type: dict[str, str] = {"id": "dataset"}
     publication_date: datetime.date = None
     languages: list[dict[str, str]] = [{"id": "eng"}]
-    title: str
+    title: str | dict[str, str]
     creators: list[DepositionCreator | DepositionCreatorResponse] | None = None
     communities: list[dict] | None = None
     description: str

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -348,9 +348,10 @@ class VersionFiles(BaseModel):
 
 
 class DepositionVersion(BaseModel):
-    """Pydantic model representing a zenodo draft deposition version.
+    """Pydantic model representing a zenodo response to POST requests.
 
-    Response returned by `create_new_deposition_version` method, which is formatted
+    Response returned by POST responses ()`create_new_deposition_version` and
+    `publish_deposition` methods, which are formatted
     differently than the response to `get_record`. There are more fields captured here
     that aren't mapped by this class, but as we are interested
     in the links, ID and metadata primarily they are not presently included,
@@ -365,5 +366,5 @@ class DepositionVersion(BaseModel):
     links: DepositionLinks
     owners: list[dict] = []
     record_url: AnyHttpUrl | None = None
-    status: Literal["new_version_draft"]
+    status: Literal["new_version_draft", "published"]
     files: VersionFiles

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -170,7 +170,7 @@ class DepositionMetadata(BaseModel):
     publication_date: datetime.date = None
     language: str = "eng"
     title: str
-    creators: list[DepositionCreator] | None = None  # To do: fix and remove None here?
+    creators: list[DepositionCreator]
     communities: list[dict] | None = None
     description: str
     access_right: str = "open"

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -366,7 +366,7 @@ class DepositionVersion(BaseModel):
     Response returned by `create_new_deposition_version` method, which is formatted
     differently than the response to `get_record`. There are more fields captured here
     that aren't mapped by this class, but as we are interested
-    in the links, id and metadata primarily they are not presently included,
+    in the links, ID and metadata primarily they are not presently included,
     as they are returned when the DOI is registered in the `get_new_version` method.
 
     See https://inveniordm.docs.cern.ch/reference/rest_api_drafts_records/#create-a-new-version.

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -64,6 +64,7 @@ class DepositionMetadata(BaseModel):
     language: str = "eng"
     title: str
     creators: list[DepositionCreator]
+    communities: list[dict] | None = None
     description: str
     access_right: str = "open"
     license_: str = Field(alias="license")
@@ -151,15 +152,28 @@ class DepositionFile(BaseModel):
 class DepositionLinks(BaseModel):
     """Pydantic model representing zenodo deposition Links."""
 
-    bucket: AnyHttpUrl | None = None
-    discard: AnyHttpUrl | None = None
-    edit: AnyHttpUrl | None = None
-    files: AnyHttpUrl | None = None
-    html: AnyHttpUrl | None = None
-    latest_draft: AnyHttpUrl | None = None
-    latest_draft_html: AnyHttpUrl | None = None
-    publish: AnyHttpUrl | None = None
     self: AnyHttpUrl | None = None
+    self_html: AnyHttpUrl | None = None
+    parent_doi: AnyHttpUrl | None = None
+    self_iiif_manifest: AnyHttpUrl | None = None
+    self_iiif_sequency: AnyHttpUrl | None = None
+    files: AnyHttpUrl | None = None
+    media_files: AnyHttpUrl | None = None
+    archive: AnyHttpUrl | None = None
+    archive_media: AnyHttpUrl | None = None
+    record: AnyHttpUrl | None = None
+    record_html: AnyHttpUrl | None = None
+    publish: AnyHttpUrl | None = None
+    review: AnyHttpUrl | None = None
+    versions: AnyHttpUrl | None = None
+    access_links: AnyHttpUrl | None = None
+    access_users: AnyHttpUrl | None = None
+    access_request: AnyHttpUrl | None = None
+    access: AnyHttpUrl | None = None
+    reserve_doi: AnyHttpUrl | None = None
+    communities: AnyHttpUrl | None = None
+    communities_suggestions: AnyHttpUrl | None = None
+    requests: AnyHttpUrl | None = None
 
 
 class Deposition(BaseModel):

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -44,9 +44,9 @@ following resources:
 class Person(BaseModel):
     """Pydantic model representing individual Zenodo deposition creators."""
 
-    type_: Literal["personal", "organizational"] | None = None
-    given_name: str | None = None
-    family_name: str | None = None
+    type_: Literal["personal", "organizational"] = Field(alias="type")
+    given_name: str
+    family_name: str
     identifiers: dict[str, str] | None = None
 
     @classmethod
@@ -78,10 +78,8 @@ class Person(BaseModel):
 class Organization(BaseModel):
     """Pydantic model representing organizational Zenodo deposition creators."""
 
-    type_: Literal[
-        "personal", "organizational"
-    ] | None = None  # TO DO: Fix to be 'type'
-    name: str | None = None
+    type_: Literal["personal", "organizational"] = Field(alias="type")
+    name: str
     identifiers: dict[str, str] | None = None
 
     @classmethod
@@ -93,7 +91,7 @@ class Organization(BaseModel):
 class Affiliation(BaseModel):
     """Pydantic model representing organization affiliations of deposition creators."""
 
-    id_: str | None = None
+    id_: str | None = Field(alias="id")
     name: str | None = None
 
     @classmethod
@@ -105,7 +103,7 @@ class Affiliation(BaseModel):
 class Role(BaseModel):
     """Pydantic model representing organization roles of deposition creators."""
 
-    id_: str | None = None
+    id_: str | None = Field(alias="id")
 
     @classmethod
     def from_contributor(cls, contributor: Contributor) -> "Role":
@@ -119,7 +117,7 @@ class DepositionCreator(BaseModel):
     See https://inveniordm.docs.cern.ch/reference/metadata/#creators-1-n.
     """
 
-    person_or_org: Person | Organization | None = None
+    person_or_org: Person | Organization
     affiliation: Affiliation | str | None = (
         None  # String is for pre-migration datapackages.
     )
@@ -128,10 +126,10 @@ class DepositionCreator(BaseModel):
     @classmethod
     def from_contributor(cls, contributor: Contributor) -> "DepositionCreator":
         """Construct deposition metadata object from PUDL Contributor model."""
-        if contributor.title == "Catalyst Cooperative":
+        if contributor.title != contributor.organization:
             person_or_org = Person.from_contributor(contributor)
         else:
-            person_or_org = Organization.from_contributor(contributor)
+            person_or_org = Organization.from_contributor(contributor)  # Debug
         return cls(
             person_or_org=person_or_org,
             affiliation=Affiliation.from_contributor(contributor),
@@ -142,7 +140,7 @@ class DepositionCreator(BaseModel):
 class License(BaseModel):
     """Pydantic model representing dataset licenses for Zenodo deposition."""
 
-    id_: str | None = None
+    id_: str | None = Field(alias="id")
     title: str | None = None
     description: str | None = None
     link: AnyHttpUrl | None = None

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -10,7 +10,12 @@ from dotenv import load_dotenv
 from pudl_archiver.depositors import ZenodoDepositor
 from pudl_archiver.depositors.zenodo import ZenodoClientException
 from pudl_archiver.utils import retry_async
-from pudl_archiver.zenodo.entities import DepositionCreator, DepositionMetadata
+from pudl_archiver.zenodo.entities import (
+    Affiliation,
+    DepositionCreator,
+    DepositionMetadata,
+    Organization,
+)
 
 
 @pytest_asyncio.fixture()
@@ -41,7 +46,10 @@ async def empty_deposition(depositor):
         title="PUDL Test",
         creators=[
             DepositionCreator(
-                name="catalyst-cooperative", affiliation="Catalyst Cooperative"
+                person_or_org=Organization(
+                    name="catalyst-cooperative", type="organizational"
+                ),
+                affiliation=Affiliation(name="catalyst-cooperative"),
             )
         ],
         description="Test dataset for the sandbox, thanks!",

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -60,7 +60,6 @@ async def empty_deposition(depositor):
 
     deposition = await depositor.create_deposition(deposition_metadata)
 
-    assert clean_metadata(deposition.metadata) == clean_metadata(deposition_metadata)
     assert deposition.state == "unsubmitted"
     return deposition
 
@@ -75,7 +74,6 @@ async def initial_deposition(depositor, empty_deposition):
         empty_deposition,
         "to_update",
         BytesIO(initial_files["to_update"]),
-        force_api="files",
     )
     await depositor.create_file(
         empty_deposition, "to_delete", BytesIO(initial_files["to_delete"])
@@ -107,10 +105,7 @@ async def test_publish_empty(depositor, empty_deposition, mocker):
         await depositor.publish_deposition(empty_deposition)
     error_json = excinfo.value.kwargs["json"]
     assert "validation error" in error_json["message"].lower()
-    assert (
-        "minimum one file must be provided"
-        in error_json["errors"][0]["message"].lower()
-    )
+    assert "missing uploaded files" in error_json["errors"][0]["messages"][0].lower()
 
 
 @pytest.mark.asyncio()

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -54,7 +54,7 @@ async def empty_deposition(depositor):
         ],
         description="Test dataset for the sandbox, thanks!",
         version="1.0.0",
-        license="CC0-1.0",
+        license={"id": "CC0-1.0"},
         keywords=["test"],
     )
 

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -78,7 +78,6 @@ async def initial_deposition(depositor, empty_deposition):
     await depositor.create_file(
         empty_deposition, "to_delete", BytesIO(initial_files["to_delete"])
     )
-
     # publish initial deposition
     return await depositor.publish_deposition(empty_deposition)
 
@@ -112,8 +111,7 @@ async def test_publish_empty(depositor, empty_deposition, mocker):
 async def test_delete_deposition(depositor, initial_deposition):
     """Make a new draft, delete it, and see that the conceptrecid still points
     at the original."""
-    draft = await depositor.get_new_version(initial_deposition)
-
+    draft = await depositor.get_new_version(initial_deposition, data_source_id="test")
     latest = await get_latest(
         depositor, initial_deposition.conceptrecid, published_only=False
     )

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -19,9 +19,11 @@ from pudl_archiver.depositors.zenodo import ZenodoClientException
 from pudl_archiver.orchestrator import DepositionOrchestrator
 from pudl_archiver.utils import retry_async
 from pudl_archiver.zenodo.entities import (
+    Affiliation,
     Deposition,
     DepositionCreator,
     DepositionMetadata,
+    Organization,
 )
 
 
@@ -38,12 +40,15 @@ def deposition_metadata():
         title="PUDL Test",
         creators=[
             DepositionCreator(
-                name="catalyst-cooperative", affiliation="Catalyst Cooperative"
+                person_or_org=Organization(
+                    name="catalyst-cooperative", type="organizational"
+                ),
+                affiliation=Affiliation(name="catalyst-cooperative"),
             )
         ],
         description="Test dataset for the sandbox, thanks!",
         version="1.0.0",
-        license="cc-zero",
+        license={"id": "CC0-1.0"},
         keywords=["test"],
     )
 

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -181,6 +181,7 @@ async def test_zenodo_workflow(
         "dry_run": False,
         "sandbox": True,
         "auto_publish": True,
+        "refresh_metadata": False,
     }
 
     class TestDownloader(AbstractDatasetArchiver):

--- a/tests/unit/frictionless_test.py
+++ b/tests/unit/frictionless_test.py
@@ -17,9 +17,9 @@ def test_datapackage():
     deposition_files = [
         DepositionFile(
             checksum="fake_hash",
-            filename=name,
+            key=name,
             id="fake_id",
-            filesize=random.randint(1, 10000),  # nosec
+            size=random.randint(1, 10000),  # nosec
             links=FileLinks(self="https://fake.url.com"),
         )
         for name in files

--- a/tests/unit/frictionless_test.py
+++ b/tests/unit/frictionless_test.py
@@ -20,7 +20,7 @@ def test_datapackage():
             filename=name,
             id="fake_id",
             filesize=random.randint(1, 10000),  # nosec
-            links=FileLinks(download="https://fake.url.com"),
+            links=FileLinks(self="https://fake.url.com"),
         )
         for name in files
     ]

--- a/tests/unit/zenodo_api_test.py
+++ b/tests/unit/zenodo_api_test.py
@@ -8,15 +8,15 @@ from pudl_archiver.orchestrator import DatasetSettings
 def test_dataset_settings():
     dataset_settings = DatasetSettings(
         production_doi="10.5281/zenodo.123456",
-        sandbox_doi="10.5072/zenodo.1234567",
+        sandbox_doi="10.5281/zenodo.1234567",
     )
 
     assert dataset_settings.production_doi == "10.5281/zenodo.123456"
-    assert dataset_settings.sandbox_doi == "10.5072/zenodo.1234567"
+    assert dataset_settings.sandbox_doi == "10.5281/zenodo.1234567"
 
     with pytest.raises(pydantic.ValidationError):
         dataset_settings = DatasetSettings(
-            sandbox_doi="10.5281/zenodo.123456",
+            sandbox_doi="10.5281/zenodo.1234",
             production_doi="10.5072/zenodo.1234567",
         )
 


### PR DESCRIPTION
See #183 for detailed issue description. Zenodo's endpoints for their API have changed, breaking our existing archivers. Let's get them migrated.

- [x] update `create_deposition`
- [x] update `get_deposition`
- [x] update `get_record`
- [x] update `get_new_version`
- [x] update `publish_deposition`
- [x] update `delete_deposition`
- [x] update `create_file`
- [x] update `delete_file`
- [x] update `update_file`
- [x] update `datapackage.json` to use new path
- [x] Update `creators` metadata to match new format https://inveniordm.docs.cern.ch/reference/metadata/#creators-1-n
- [x] fix license https://inveniordm.docs.cern.ch/reference/metadata/#rights-licenses-0-n
- [x] deal with key names that mask python methods
- [x] debug `delete_deposition` 
- [x] update Zenodo sandbox APIs to `.5281` prefix and new values
- [x] check if old API still works - it does not
- [x] check to make sure new datapackage format for newly created archives is the same as the old version
- [x] fix tests to expect different response than what is posted for metadata
- [x] Drop `/content` extension from datapackage
- [x] Figure out how to deal with metadata updates from existing production archives - add `refresh_metadata` flag
- [x] fix datapackage.json to remove content headers
- [ ] once reviewed: make new sandbox archives for: `census_dp1tract`, `eia176`, `eia860`, `eiawater`, `epacems`, `ferc60` and update sandbox dois for all data sources

Out of scope:
- add community to post https://inveniordm.docs.cern.ch/reference/metadata/#future-directions (maybe not yet possible?)

Check that the code works for:
- [x] non-flagged update run
- [x] dataset with partitions
- [x] `--sandbox`
- [x] `--dry-run`
- [x] `--initialize`

Updates about remaining kinks in the transition:
- When testing `--auto-publish` on the sandbox server - I get a "Attempt to decode JSON with unexpected mimetype: text/html" 404 error. Underlying this is a 504 Gateway Timeout for the sandbox. This also means the tests fail.
- The [API documentation](https://inveniordm.docs.cern.ch/reference/rest_api_drafts_records/#download-a-draft-file) says to use the /content file link to GET a file. There are two options here: "https://zenodo.org/api/records/10064652/files/eia923-2023.zip/content" and "https://zenodo.org/records/10064652/files/eia923-2023.zip" - presuming in this PR that we prefer the latter?
- Sandbox DOIs are unstable and likely to change again. It's still unclear whether the transition from 10.5072 to 10.5281 for sandbox DOIs is permanent. Sandbox DOIs are not actually being really registered right now, based on email communication with Zenodo technical support.
- The `creators` field response != the `creators` field expected format. This means you can't `GET` a deposition and `PUT` its metadata back. Updating a draft record with one field (e.g. the `order` field for the `files` dictionary) also seems to wipe all the rest of the inputted values for the `metadata`. Very annoying behavior that means we should avoid updating records by any means other than linking once they're created.