### PR TITLE
Set up Ruff and fix dependency conflicts with PUDL repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage.xml
 .env_tox
 .env
 **/*~
+.hypothesis/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,6 @@ repos:
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      - id: python-check-blanket-noqa # Prohibit overly broad QA exclusions.
-      - id: python-no-eval # Never use eval() it's dangerous.
-      - id: python-no-log-warn # logger.warning(), not old .warn()
       - id: rst-backticks # Find single rather than double backticks
       - id: rst-directive-colons # Missing double-colons after directives
       - id: rst-inline-touching-normal # Inline code should never touch normal text
@@ -20,7 +17,6 @@ repos:
       - id: check-yaml # Validate all YAML files.
       - id: check-case-conflict # Avoid case sensitivity in file names.
       - id: debug-statements # Watch for lingering debugger calls.
-      - id: end-of-file-fixer # Ensure there's a newline at EOF.
       - id: mixed-line-ending # Only newlines, no line-feeds.
       - id: trailing-whitespace # Remove trailing whitespace.
       - id: name-tests-test # Follow PyTest naming convention.
@@ -29,42 +25,18 @@ repos:
   #####################################################################################
   # Formatters: hooks that re-write Python and RST files
   #####################################################################################
-
-  # Convert relative imports to absolute imports
-  - repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
     hooks:
-      - id: absolufy-imports
-
-  # Make sure import statements are sorted uniformly.
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-
-  # Remove f-string prefix when there's nothing in the string to format.
-  - repo: https://github.com/dannysepler/rm_unneeded_f_str
-    rev: v0.2.0
-    hooks:
-      - id: rm-unneeded-f-str
-
-  - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: "v1.0"
-    hooks:
-      - id: upgrade-type-hints
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py310-plus"]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
 
   # Deterministic python formatting:
   - repo: https://github.com/psf/black
     rev: 23.11.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.11
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
@@ -76,46 +48,12 @@ repos:
   # Linters: hooks that check but don't alter Python & RST files
   ########################################################################################
 
-  # Check for PEP8 non-compliance, code complexity, style, errors, etc:
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        args: ["--config", "tox.ini"]
-        additional_dependencies:
-          - flake8-docstrings
-          - flake8-colors
-          - pydocstyle
-          - flake8-builtins
-          - mccabe
-          - pep8-naming
-          - pycodestyle
-          - pyflakes
-          - flake8-rst-docstrings
-          - flake8-use-fstring
-
-  # Check for known security vulnerabilities:
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
-    hooks:
-      - id: bandit
-        additional_dependencies: ["bandit[toml]"]
-        args: ["--configfile", "pyproject.toml"]
-
   # Check for errors in restructuredtext (.rst) files under the doc hierarchy
   - repo: https://github.com/PyCQA/doc8
     rev: v1.1.1
     hooks:
       - id: doc8
-        args: ["--config", "tox.ini"]
-
-  # Lint any RST files and embedded code blocks for syntax / formatting errors
-  - repo: https://github.com/rstcheck/rstcheck
-    rev: v6.2.0
-    hooks:
-      - id: rstcheck
-        additional_dependencies: [sphinx]
-        args: ["--config", "tox.ini"]
+        args: ["--config", "pyproject.toml"]
 
   # Lint Dockerfiles for errors and to ensure best practices
   - repo: https://github.com/AleksaC/hadolint-py

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 ---
-name: pudl-cataloger
+name: pudl-archiver
 channels:
   - conda-forge
   - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 ---
-name: pudl-archiver
+name: pudl-cataloger
 channels:
   - conda-forge
   - defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,12 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "black>=22.0,<23.12",  # A deterministic code formatter
-    "isort>=5.0,<5.13",  # Standardized import sorting
-    "tox>=3.20,<4.12",  # Python test environment manager
+    "build>=1.0,<1.1",
+    "ruff>=0.1,<0.2",
+    "tox>=4.0,<4.12",  # Python test environment manager
     "twine>=3.3,<4.1",  # Used to make releases to PyPI
-    "mypy",
     "types-requests",
 ]
-
 
 docs = [
     "doc8>=0.9,<1.2",  # Ensures clean documentation formatting
@@ -47,17 +46,8 @@ docs = [
 ]
 
 tests = [
-    "bandit[toml]>=1.6,<1.8",  # Checks code for security issues
     "coverage>=5.3,<7.4",  # Lets us track what code is being tested
     "doc8>=0.9,<1.2",  # Ensures clean documentation formatting
-    "flake8>=4.0,<6.2",  # A framework for linting & static analysis
-    "flake8-builtins>=1.5,<2.3",  # Avoid shadowing Python built-in names
-    "flake8-colors>=0.1,<0.2",  # Produce colorful error / warning output
-    "flake8-docstrings>=1.5,<1.8",  # Ensure docstrings are formatted well
-    "flake8-rst-docstrings>=0.2,<0.4",  # Allow use of ReST in docstrings
-    "flake8-use-fstring>=1.0,<1.5",  # Highlight use of old-style string formatting
-    "mccabe>=0.6,<0.8",  # Checks that code isn't overly complicated
-    "pep8-naming>=0.12,<0.14",  # Require PEP8 compliant variable names
     "pre-commit>=2.9,<3.6",  # Allow us to run pre-commit hooks in testing
     "pydocstyle>=5.1,<6.4",  # Style guidelines for Python documentation
     "pytest>=6.2,<7.5",  # Our testing framework
@@ -65,7 +55,7 @@ tests = [
     "pytest-console-scripts>=1.1,<1.5",  # Allow automatic testing of scripts
     "pytest-cov>=2.10,<4.2",  # Pytest plugin for working with coverage
     "pytest-mock>=3.0,<3.13",  # Pytest plugin for mocking function calls and objects
-    "rstcheck[sphinx]>=5.0,<6.2",  # ReStructuredText linter
+    "ruff>=0.1,<0.2",
 ]
 
 [project.scripts]
@@ -79,12 +69,101 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ["py310"]
+target-version = ["py311"]
 include = "\\.pyi?$"
 
-[tool.isort]
-profile = "black"
-known_first_party = ["pudl", "pudl_catalog", "pudl_archiver"]
+[tool.doc8]
+max-line-length = 88
+ignore-path = ["docs/_build"]
 
-[tool.bandit]
-skips = ["B101"]
+[tool.pytest.ini_options]
+testpaths = "./"
+filterwarnings = [
+    "ignore:distutils Version classes are deprecated:DeprecationWarning",
+    "ignore:Creating a LegacyVersion:DeprecationWarning:pkg_resources[.*]",
+]
+addopts = "--verbose"
+log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
+log_cli = "true"
+log_cli_level = "INFO"
+doctest_optionflags = [
+    "NORMALIZE_WHITESPACE",
+    "IGNORE_EXCEPTION_DETAIL",
+    "ELLIPSIS",
+]
+
+[tool.ruff]
+select = [
+    "A", # flake8-builtins
+    # "ARG", # unused arguments
+    # "B",  # flake8-bugbear
+    "C",   # Limit cyclomatic complexity using mccabe
+    "D",   # pydocstyle errors
+    "E",   # pycodestyle errors
+    "EXE", # executable file issues
+    # "ERA", # eradicate: find commented out code
+    "F",   # pyflakes
+    "I",   # isort
+    "ISC", # implicit string concatenation
+    "N",   # pep8-naming
+    "NPY", # NumPy specific checks
+    "PD",  # pandas checks
+    "PGH", # pygrep-hooks
+    # "PL",  # pylint
+    # "PT",  # pytest style
+    "PTH", # use pathlib
+    "Q",   # flake8-quotes
+    "RET", # check return values
+    "RSE", # unnecessary parenthises on raised exceptions
+    "S",   # flake8-bandit
+    "SIM", # flake8-simplify
+    # "T",   # print statements found
+    "UP", # pyupgrade (use modern python syntax)
+    "W",  # pycodestyle warnings
+]
+ignore = [
+    "D401",   # Require imperative mood in docstrings.
+    "D417",
+    "E501",   # Overlong lines.
+    "E203",   # Space before ':' (black recommends to ignore)
+    "PD003",  # Use of isna rather than isnull
+    "PD004",  # Use of notna rather than notnull
+    "PD008",  # Use of df.at[] rather than df.loc[]
+    "PD010",  # Use of df.stack()
+    "PD013",  # Use of df.unstack()
+    "PD015",  # Use of pd.merge() rather than df.merge()
+    "PD901",  # df as variable name
+    "RET504", # Ignore unnecessary assignment before return
+    "S101",   # Use of assert
+]
+
+# Assume Python 3.11
+target-version = "py311"
+line-length = 88
+
+# Don't automatically concatenate strings -- sometimes we forget a comma!
+unfixable = ["ISC"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]    # Ignore unused imports
+"tests/*" = ["D"]
+
+[tool.ruff.pep8-naming]
+# Allow Pydantic's `@validator` decorator to trigger class method treatment.
+classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
+
+[tool.ruff.isort]
+known-first-party = ["ferc_xbrl_extractor"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
+
+[tool.ruff.flake8-quotes]
+docstring-quotes = "double"
+inline-quotes = "double"
+multiline-quotes = "double"
+

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -3,11 +3,11 @@ import asyncio
 import json
 import logging
 import os
-import pathlib
+from pathlib import Path
 
 import aiohttp
 
-import pudl_archiver.orchestrator  # noqa: 401
+import pudl_archiver.orchestrator  # noqa: F401
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver
 from pudl_archiver.archivers.validate import Unchanged
 from pudl_archiver.orchestrator import DepositionOrchestrator
@@ -17,11 +17,11 @@ logger = logging.getLogger(f"catalystcoop.{__name__}")
 
 def all_archivers():
     """List all Archivers that have been defined."""
-    dirpath = pathlib.Path(__file__).parent
+    dirpath = Path(__file__).parent
     pyfiles = [
         path.relative_to(dirpath)
         for path in dirpath.glob("archivers/**/*.py")
-        if "__init__" != path.stem
+        if path.stem != "__init__"
     ]
     module_names = [f"pudl_archiver.{str(p).replace('/', '.')[:-3]}" for p in pyfiles]
     for module in module_names:
@@ -75,15 +75,14 @@ async def archive_datasets(
             cls = ARCHIVERS.get(dataset)
             if not cls:
                 raise RuntimeError(f"Dataset {dataset} not supported")
-            else:
-                downloader = cls(session, only_years, download_directory=download_dir)
+            downloader = cls(session, only_years, download_directory=download_dir)
             orchestrator = DepositionOrchestrator(
                 dataset,
                 downloader,
                 session,
                 upload_key,
                 publish_key,
-                deposition_settings=pathlib.Path("dataset_doi.yaml"),
+                deposition_settings=Path("dataset_doi.yaml"),
                 create_new=initialize,
                 dry_run=dry_run,
                 sandbox=sandbox,
@@ -109,7 +108,7 @@ async def archive_datasets(
     if summary_file is not None:
         run_summaries = [result.dict() for _, result in results]
 
-        with open(summary_file, "w") as f:
+        with Path.open(summary_file, "w") as f:
             json.dump(run_summaries, f, indent=2)
 
     # Check validation results of all runs that aren't unchanged

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -39,7 +39,7 @@ async def archive_datasets(
     initialize: bool = False,
     only_years: list[int] | None = None,
     dry_run: bool = True,
-    summary_file: str | None = None,
+    summary_file: Path | None = None,
     download_dir: str | None = None,
     auto_publish: bool = False,
 ):
@@ -108,8 +108,8 @@ async def archive_datasets(
     if summary_file is not None:
         run_summaries = [result.dict() for _, result in results]
 
-        with Path.open(summary_file, "w") as f:
-            json.dump(run_summaries, f, indent=2)
+        with summary_file.open("w") as f:
+            f.write(json.dumps(run_summaries, indent=2))
 
     # Check validation results of all runs that aren't unchanged
     validation_results = [

--- a/src/pudl_archiver/archivers/epacems.py
+++ b/src/pudl_archiver/archivers/epacems.py
@@ -95,7 +95,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
                 for file in bulk_files
                 if (file["metadata"]["dataType"] == "Emissions")
                 and (file["metadata"]["dataSubType"] == "Hourly")
-                and ("stateCode" in file["metadata"].keys())
+                and ("stateCode" in file["metadata"])
                 and (self.valid_year(file["metadata"]["year"]))
             ]
             logger.info(f"Downloading {len(hourly_state_emissions_files)} total files.")

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -231,7 +231,7 @@ async def archive_taxonomy(
 
     # Loop through all files and save to appropriate location in archive
     with zipfile.ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
-        for url in taxonomy.urlDocs.keys():
+        for url in taxonomy.urlDocs:
             url_parsed = urlparse(url)
 
             # There are some generic XML/XBRL files in the taxonomy that should be skipped

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """A script for archiving raw PUDL data on Zenodo."""
 
 import argparse

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -5,10 +5,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import AnyHttpUrl, BaseModel, Field
-
 from pudl.metadata.classes import Contributor, DataSource, License
 from pudl.metadata.constants import CONTRIBUTORS
+from pydantic import AnyHttpUrl, BaseModel, Field
+
 from pudl_archiver.zenodo.entities import DepositionFile
 
 ResourceInfo = namedtuple("ResourceInfo", ["local_path", "partitions"])

--- a/src/pudl_archiver/utils.py
+++ b/src/pudl_archiver/utils.py
@@ -34,7 +34,7 @@ async def retry_async(
         args = []
     if kwargs is None:
         kwargs = {}
-    for try_count in range(1, retry_count + 1):
+    for try_count in range(1, retry_count + 1):  # noqa: RET503
         # try count is 1 indexed for logging clarity
         coro = async_func(*args, **kwargs)
         try:

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -6,9 +6,8 @@ import datetime
 import re
 from typing import Literal
 
-from pydantic import AnyHttpUrl, BaseModel, ConstrainedStr, Field, validator
-
 from pudl.metadata.classes import Contributor, DataSource
+from pydantic import AnyHttpUrl, BaseModel, ConstrainedStr, Field, validator
 
 
 class Doi(ConstrainedStr):
@@ -76,7 +75,7 @@ class DepositionMetadata(BaseModel):
     def check_empty_string(cls, doi: str):  # noqa: N805
         """Sometimes zenodo returns an empty string for the `doi`. Convert to None."""
         if doi == "":
-            return None
+            return
 
     @classmethod
     def from_data_source(cls, data_source_id: str) -> "DepositionMetadata":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 
 import pytest
-
 from pudl_archiver.frictionless import DataPackage
 
 

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -6,9 +6,8 @@ import aiohttp
 import pytest
 import pytest_asyncio
 from dotenv import load_dotenv
-
 from pudl_archiver.depositors import ZenodoDepositor
-from pudl_archiver.depositors.zenodo import ZenodoClientException
+from pudl_archiver.depositors.zenodo import ZenodoClientError
 from pudl_archiver.utils import retry_async
 from pudl_archiver.zenodo.entities import DepositionCreator, DepositionMetadata
 
@@ -83,7 +82,7 @@ async def get_latest(depositor, conceptdoi, published_only=False):
         args=[conceptdoi],
         kwargs={"published_only": published_only},
         retry_on=(
-            ZenodoClientException,
+            ZenodoClientError,
             aiohttp.ClientError,
             asyncio.TimeoutError,
             IndexError,
@@ -95,7 +94,7 @@ async def get_latest(depositor, conceptdoi, published_only=False):
 async def test_publish_empty(depositor, empty_deposition, mocker):
     # try publishing empty
     mocker.patch("asyncio.sleep", mocker.AsyncMock())
-    with pytest.raises(ZenodoClientException) as excinfo:
+    with pytest.raises(ZenodoClientError) as excinfo:
         await depositor.publish_deposition(empty_deposition)
     error_json = excinfo.value.kwargs["json"]
     assert "validation error" in error_json["message"].lower()

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -10,12 +10,11 @@ import pytest
 import pytest_asyncio
 import requests
 from dotenv import load_dotenv
-
 from pudl.metadata.classes import DataSource
 from pudl.metadata.constants import LICENSES
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver, ResourceInfo
 from pudl_archiver.archivers.validate import Unchanged
-from pudl_archiver.depositors.zenodo import ZenodoClientException
+from pudl_archiver.depositors.zenodo import ZenodoClientError
 from pudl_archiver.orchestrator import DepositionOrchestrator
 from pudl_archiver.utils import retry_async
 from pudl_archiver.zenodo.entities import (
@@ -107,7 +106,7 @@ def test_files():
                 # Add to files
                 files[dep_type].append({"path": path, "contents": contents})
 
-                with open(path, "wb") as f:
+                with Path.open(path, "wb") as f:
                     f.write(contents)
 
         yield files
@@ -131,7 +130,7 @@ def test_settings():
     """Create temporary DOI settings file."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         settings_file = Path(tmp_dir) / "settings.yaml"
-        with open(settings_file, "w") as f:
+        with Path.open(settings_file, "w") as f:
             f.writelines(["fake_dataset:\n", "    sandbox_doi: null"])
 
         yield settings_file
@@ -274,7 +273,7 @@ async def test_zenodo_workflow(
         args=[str(orchestrator.deposition.conceptdoi)],
         kwargs={"published_only": True},
         retry_on=(
-            ZenodoClientException,
+            ZenodoClientError,
             aiohttp.ClientError,
             asyncio.TimeoutError,
             IndexError,

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pytest
 from aiohttp import ClientSession
-
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver, ArchiveAwaitable
 from pudl_archiver.archivers.validate import ValidationTestResult
 from pudl_archiver.frictionless import Resource, ResourceInfo
@@ -19,7 +18,7 @@ def bad_zipfile():
     """Create a fake bad zipfile as a temp file."""
     with tempfile.TemporaryDirectory() as path:
         zip_path = Path(path) / "test.zip"
-        with open(zip_path, "wb") as archive:
+        with Path.open(zip_path, "wb") as archive:
             archive.write(b"Fake non-zipfile data")
 
         yield zip_path
@@ -30,9 +29,10 @@ def good_zipfile():
     """Create a fake good zipfile in temporary directory."""
     with tempfile.TemporaryDirectory() as path:
         zip_path = Path(path) / "test.zip"
-        with zipfile.ZipFile(zip_path, "w") as archive:
-            with archive.open("test.txt", "w") as file:
-                file.write(b"Test good zipfile")
+        with zipfile.ZipFile(zip_path, "w") as archive, archive.open(
+            "test.txt", "w"
+        ) as file:
+            file.write(b"Test good zipfile")
 
         yield zip_path
 

--- a/tests/unit/archive_validate_test.py
+++ b/tests/unit/archive_validate_test.py
@@ -1,6 +1,5 @@
 """Test archive validate module."""
 import pytest
-
 from pudl_archiver.archivers import validate
 from pudl_archiver.frictionless import Resource
 

--- a/tests/unit/eia_archiver_test.py
+++ b/tests/unit/eia_archiver_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pudl_archiver.archivers.eia860 import Eia860Archiver
 from pudl_archiver.archivers.eia860m import Eia860MArchiver
 from pudl_archiver.archivers.eia861 import Eia861Archiver

--- a/tests/unit/eiawater_test.py
+++ b/tests/unit/eiawater_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pudl_archiver.archivers.eiawater import EiaWaterArchiver
 
 

--- a/tests/unit/ferc_archiver_test.py
+++ b/tests/unit/ferc_archiver_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pudl_archiver.archivers.ferc.ferc1 import Ferc1Archiver
 from pudl_archiver.archivers.ferc.ferc2 import Ferc2Archiver
 from pudl_archiver.archivers.ferc.ferc6 import Ferc6Archiver

--- a/tests/unit/frictionless_test.py
+++ b/tests/unit/frictionless_test.py
@@ -3,7 +3,6 @@ import random
 from pathlib import Path
 
 from frictionless.package import Package
-
 from pudl_archiver.archivers.classes import ResourceInfo
 from pudl_archiver.frictionless import DataPackage
 from pudl_archiver.zenodo.entities import DepositionFile, FileLinks
@@ -19,7 +18,7 @@ def test_datapackage():
             checksum="fake_hash",
             filename=name,
             id="fake_id",
-            filesize=random.randint(1, 10000),  # nosec
+            filesize=random.randint(1, 10000),  # noqa: S311
             links=FileLinks(download="https://fake.url.com"),
         )
         for name in files

--- a/tests/unit/pudl_archiver_test.py
+++ b/tests/unit/pudl_archiver_test.py
@@ -1,6 +1,5 @@
 """Test archiver pudl_archiver."""
 import pytest
-
 from pudl_archiver import archive_datasets
 from pudl_archiver.archivers.validate import RunSummary, Unchanged, ValidationTestResult
 
@@ -50,7 +49,7 @@ def failed_run():
 @pytest.mark.asyncio
 async def test_archive_datasets(successful_run, failed_run, unchanged_run, mocker):
     """Test that archive datasets creates run_summary file."""
-    open_mock = mocker.patch("pudl_archiver.open")
+    open_mock = mocker.patch("pudl_archiver.Path.open")
     open_mock.return_value.__enter__.return_value = "file"
     mocked_json_dump = mocker.patch("pudl_archiver.json.dump")
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,7 +1,6 @@
 from asyncio import to_thread
 
 import pytest
-
 from pudl_archiver.utils import retry_async
 
 

--- a/tests/unit/zenodo_api_test.py
+++ b/tests/unit/zenodo_api_test.py
@@ -1,7 +1,6 @@
 """Test zenodo API client."""
 import pydantic
 import pytest
-
 from pudl_archiver.orchestrator import DatasetSettings
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,21 +25,13 @@ covreport = coverage report --sort=cover
 #######################################################################################
 # Code and Documentation Linters
 #######################################################################################
-[testenv:flake8]
-description = Run the full suite of flake8 linters & static code analysis
+[testenv:ruff]
+description = Run the ruff linter on the whole repo
 skip_install = false
 extras =
     tests
 commands =
-    flake8 --config tox.ini
-
-[testenv:rstcheck]
-description = Check formatting and syntax of RST files.
-skip_install = false
-extras =
-    tests
-commands =
-    rstcheck --config tox.ini --recursive ./
+    ruff check ./
 
 [testenv:pre_commit]
 description = Run git pre-commit hooks not covered by the other linters.
@@ -47,36 +39,21 @@ skip_install = false
 extras =
     tests
 commands =
-    pre-commit run --all-files --show-diff-on-failure python-no-eval
-    pre-commit run --all-files --show-diff-on-failure python-no-log-warn
-    pre-commit run --all-files --show-diff-on-failure python-check-blanket-noqa
     pre-commit run --all-files --show-diff-on-failure check-merge-conflict
     pre-commit run --all-files --show-diff-on-failure check-yaml
     pre-commit run --all-files --show-diff-on-failure check-case-conflict
     pre-commit run --all-files --show-diff-on-failure debug-statements
     pre-commit run --all-files --show-diff-on-failure name-tests-test
 
-[testenv:bandit]
-description = Check the codebase for common insecure code patterns.
-skip_install = false
-extras =
-    tests
-commands =
-    bandit -r src/pudl_archiver/
-
 [testenv:linters]
 description = Run the pre-commit, flake8 and bandit linters.
 skip_install = false
 extras =
     {[testenv:pre_commit]extras}
-    {[testenv:bandit]extras}
-    {[testenv:rstcheck]extras}
-    {[testenv:flake8]extras}
+    {[testenv:ruff]extras}
 commands =
     {[testenv:pre_commit]commands}
-    {[testenv:bandit]commands}
-    {[testenv:rstcheck]commands}
-    {[testenv:flake8]commands}
+    {[testenv:ruff]commands}
 
 
 #######################################################################################
@@ -103,69 +80,3 @@ commands =
     {[testenv:linters]commands}
     {[testenv:unit]commands}
     {[testenv]covreport}
-
-#######################################################################################
-# Configuration for various tools.
-#######################################################################################
-[pytest]
-testpaths = .
-addopts = --verbose
-log_format = %(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s
-log_date_format= %Y-%m-%d %H:%M:%S
-log_cli = True
-log_cli_level = INFO
-doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
-filterwarnings =
-    ignore:distutils Version classes are deprecated:DeprecationWarning
-    ignore:Creating a LegacyVersion:DeprecationWarning:pkg_resources[.*]
-
-[flake8]
-# A few linter errors and warnings that we are currently ignoring:
-# * W503, W504: Line break before / after binary operator.
-# * D401: Imperative mood.
-# * E501: Overlong line
-# * E203: Space before ':' (black recommends to ignore)
-# * RST201,RST203,RST301: Google docstrings aren't RST until after being processed by
-#   Napoleon. See https://github.com/peterjc/flake8-rst-docstrings/issues/17
-extend-ignore = W503,W504,D401,E501,E203,RST201,RST203,RST301,
-inline-quotes = double
-max-line-length = 88
-docstring-convention = google
-# Files and directories that should not be subject to linting
-extend-exclude =
-    .env_tox,
-    .eggs,
-    build,
-# We have a backlog of complex functions being skipped with noqa: C901
-max-complexity = 10
-format = ${cyan}%(path)s${reset}:${green}%(row)-4d${reset} ${red_bold}%(code)s${reset} %(text)s
-rst-roles =
-    attr,
-    class,
-    doc,
-    func,
-    meth,
-    mod,
-    obj,
-    py:const,
-    ref,
-    user,
-rst-directives =
-    envvar,
-    exception,
-percent-greedy = 2
-format-greedy = 2
-# Don't force docstrings in tests
-per-file-ignores =
-    tests/*: D
-
-[doc8]
-max-line-length = 88
-ignore-path =
-    docs/_build
-
-[rstcheck]
-report_level = warning
-ignore_roles = pr,issue,user
-ignore_messages = (Hyperlink target ".*" is not referenced\.$|Duplicate implicit target name:)
-ignore_directives = bibliography,todo


### PR DESCRIPTION
I went in to try and investigate the inclusion of draft URLs in the `datapackage.json` metadata, and discovered that there were conflicts between the dependencies in `pudl-archiver` and the main PUDL repo, so it could never solve the environment.

While resolving that I went ahead and switched over to using the Ruff linter in this repo and fixed some issues it highlighted.

There's still one failing unit test though, which is maybe related to some mocking? Which I don't really understand. I tried to switch it from mocking `open` to mocking `Path.open` which seems to have worked, but this seems to have messed up another call to open. :-/ 

```
pytest tests/unit/pudl_archiver_test.py::test_archive_datasets
```

I tried to do a dry-run of archiving the `eia861` to see if the draft paths were still there, but it failed with a bunch of other problems.