### PR TITLE
Update schedule to be quarterly

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -4,10 +4,7 @@ name: run-archiver
 on:
   workflow_dispatch:
   schedule:
-    - cron: "21 4 * * 0" # Sundays 4:21 AM UTC
-  push:
-    branches:
-      - "daz/**"
+    - cron: "21 4 1 */3 *" # 4:21 AM UTC, 1st of Jan/Apr/Jul/Oct
 
 jobs:
   archive-run:
@@ -17,24 +14,10 @@ jobs:
     strategy:
       matrix:
         dataset:
-          - censusdp1tract
-          - eia176
           - eia860
           - eia860m
-          - eia861
           - eia923
-          - eia_bulk_elec
-          - eiawater
-          - epacamd_eia
           - epacems
-          - ferc1
-          - ferc2
-          - ferc6
-          - ferc60
-          - ferc714
-          - ferceqr
-          - mshamines
-          - phmsagas
 
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -4,7 +4,7 @@ name: run-archiver
 on:
   workflow_dispatch:
   schedule:
-    - cron: "21 4 1 */3 *" # 4:21 AM UTC, 1st of Jan/Apr/Jul/Oct
+    - cron: "21 4 1 * *" # 4:21 AM UTC, first of every month
 
 jobs:
   archive-run:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 .env
 **/*~
 .hypothesis/*
+.vscode/*

--- a/tests/unit/pudl_archiver_test.py
+++ b/tests/unit/pudl_archiver_test.py
@@ -55,6 +55,14 @@ async def test_archive_datasets(
     tmp_path,
 ):
     """Test that archive datasets creates run_summary file."""
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "ZENODO_SANDBOX_TOKEN_UPLOAD": "bogus",
+            "ZENODO_SANDBOX_TOKEN_PUBLISH": "bogus too",
+        },
+    )
+
     summary_file = tmp_path / "summary_file"
     with summary_file.open("w") as f:
         f.write("file")


### PR DESCRIPTION
Also, only archive the specific datasets requested by RMI... should be easy to add the rest back in later, but for now I want to keep the system small.

Closes catalyst-cooperative/pudl#3066