### PR TITLE
PHMSA archiver: add multi-year years partition, add new dataset

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -48,4 +48,4 @@ mshamines:
   sandbox_doi: 10.5072/zenodo.1158828
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
-  sandbox_doi: 10.5072/zenodo.1161321
+  sandbox_doi: 10.5072/zenodo.3357

--- a/src/pudl_archiver/archivers/phmsagas.py
+++ b/src/pudl_archiver/archivers/phmsagas.py
@@ -89,7 +89,6 @@ class PhmsaGasArchiver(AbstractDatasetArchiver):
         return ResourceInfo(
             local_path=download_path,
             partitions={
-                "start_year": start_year,
                 "years": years,
                 "form": form,
             },


### PR DESCRIPTION
Adds a multi-year `years` partition to the datapackage which includes a list of all years included in a multi-year ZIP file, and adds a new dataset while we're at it.

See sample sandbox archive [here](https://sandbox.zenodo.org/records/1981).

- [x] PUDL `datastore` can ingest listed partitions without breakdown
- [x] Change `dataset` partition to `form` to avoid `datastore` naming conflicts

After #177 merged, we should run a production archive and check that `datapackage.json` is valid using `frictionless`.