### PR TITLE
Prod Zenodo tweaks

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -12,7 +12,7 @@ eia860m:
   sandbox_doi: 10.5072/zenodo.692654
 eia861:
   production_doi: 10.5281/zenodo.4127028
-  sandbox_doi: 10.5072/zenodo.672198
+  sandbox_doi: 10.5072/zenodo.1441
 eia923:
   production_doi: 10.5281/zenodo.4127039
   sandbox_doi: 10.5072/zenodo.672220

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -70,7 +70,7 @@ class RunSummary(BaseModel):
     validation_tests: list[ValidationTestResult]
     file_changes: list[FileDiff]
     version: str = ""
-    pervious_version: str = ""
+    previous_version: str = ""
     date: str
     previous_version_date: str
 

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -338,7 +338,7 @@ class ZenodoDepositor:
             if e.status != 404:
                 raise e
             logger.info(
-                f"Got 404 when deleting {deposition.links.self}, assuming "
+                f"404 Not Found when deleting {deposition.links.self}, assume "
                 "earlier delete succeeded."
             )
 

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -215,11 +215,9 @@ class DepositionOrchestrator:
         async for name, resource in self.downloader.download_all_resources():
             resources[name] = resource
             change = self._generate_changes(name, resource)
-
             # Leave immediately after generating changes if dry_run
             if self.dry_run:
                 continue
-
             if change:
                 changed = True
                 await self._apply_change(change)

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -122,11 +122,13 @@ class FileLinks(BaseModel):
         *.zenodo.org/records/<record_id>/files/<filename>
         """
         match = re.match(
-            r"(?P<base_url>https?://.*.zenodo.org).*"
+            r"(?P<base_url>https?://.*zenodo.org).*"
             r"(?P<record_id>/records/\d+).*"
             r"(?P<filename>/files/[^/]+)",
             self.download,
         )
+        if match is None:
+            raise ValueError(f"Got bad Zenodo download URL: {self.download}")
         return "".join(match.groups())
 
 

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -119,7 +119,12 @@ class FileLinks(BaseModel):
     def canonical(self):
         """The most stable URL that points at this file.
 
-        *.zenodo.org/records/<record_id>/files/<filename>
+        Can be:
+        https://zenodo.org/records/<record_id>/files/<filename>
+        https://www.zenodo.org/records/<record_id>/files/<filename>
+        https://sandbox.zenodo.org/records/<record_id>/files/<filename>
+
+        We extract the record ID and filename from the file's download link.
         """
         match = re.match(
             r"(?P<base_url>https?://.*zenodo.org).*"

--- a/tests/integration/zenodo_depositor_test.py
+++ b/tests/integration/zenodo_depositor_test.py
@@ -126,21 +126,14 @@ async def test_get_new_version_clobbers(depositor, initial_deposition, mocker):
     delete it, and see that the conceptdoi still points
     at the original."""
     mocker.patch("asyncio.sleep", mocker.AsyncMock())
-    bad_draft = await depositor.get_new_version(initial_deposition)
+    clobberee = await depositor.get_new_version(initial_deposition)
     with pytest.raises(ZenodoClientError) as excinfo:
         await depositor.get_new_version(initial_deposition, clobber=False)
         assert (
             "remove all files first" in excinfo.value.errors[0]["messages"][0].lower()
         )
 
-    latest = await get_latest(
-        depositor, initial_deposition.conceptdoi, published_only=False
-    )
-    assert latest.id_ == bad_draft.id_
-
-    clobbering = await depositor.get_new_version(initial_deposition, clobber=True)
-    latest = await get_latest(
-        depositor, initial_deposition.conceptdoi, published_only=False
-    )
-    assert latest.id_ == clobbering.id_
-    assert initial_deposition.conceptdoi == clobbering.conceptdoi
+    clobberer = await depositor.get_new_version(initial_deposition, clobber=True)
+    # assuming that ID is a monotonically increasing number, the clobberer should be bigger than the clobberee
+    assert clobberee.id_ < clobberer.id_
+    assert initial_deposition.conceptdoi == clobberer.conceptdoi

--- a/tests/unit/zenodo_entities_test.py
+++ b/tests/unit/zenodo_entities_test.py
@@ -34,6 +34,11 @@ def test_depo_metadata_from_data_source():
             id="not_sandbox",
         ),
         pytest.param(
+            "http://zenodo.org/api/records/405/files/unchanged_file.txt/content",
+            "http://zenodo.org/records/405/files/unchanged_file.txt",
+            id="no_subdomain",
+        ),
+        pytest.param(
             "http://www.zenodo.org/records/405/files/unchanged_file.txt",
             "http://www.zenodo.org/records/405/files/unchanged_file.txt",
             id="already_canonical",


### PR DESCRIPTION
* handling deposition deletion flakiness a little more gracefully
* wrongly assumed that zenodo URL would always have a subdomain e.g. `https://www.zenodo.org` - but instead sometimes it's `https://zenodo.org`. Fixed regex.
* update test to allow for slow updates on zenodo side