### PR TITLE
Update datapackage.json, but only sometimes

### DIFF
--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -183,7 +183,7 @@ class DepositionOrchestrator:
         """
         await self._initialize()
 
-        resources = await self._upload_resources(self.downloader)
+        resources = await self._download_then_upload_resources(self.downloader)
         for deletion in self._get_deletions(resources):
             await self._apply_change(deletion)
 
@@ -207,7 +207,7 @@ class DepositionOrchestrator:
 
         return run_summary
 
-    async def _upload_resources(
+    async def _download_then_upload_resources(
         self, downloader: AbstractDatasetArchiver
     ) -> dict[str, ResourceInfo]:
         resources = {}

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -1,6 +1,7 @@
 """Core routines for archiving raw data packages."""
 import io
 import logging
+import re
 from dataclasses import dataclass
 from enum import Enum, auto
 from hashlib import md5
@@ -146,7 +147,12 @@ class DepositionOrchestrator:
     async def _initialize(self):
         if self.create_new:
             doi = None
-            self.deposition = await self._create_deposition(self.data_source_id)
+            metadata = DepositionMetadata.from_data_source(self.data_source_id)
+            if not metadata.keywords:
+                raise AssertionError(
+                    "New dataset is missing keywords and cannot be archived."
+                )
+            self.deposition = await self.depositor.create_deposition(metadata)
         else:
             settings = self.dataset_settings[self.data_source_id]
             doi = settings.sandbox_doi if self.sandbox else settings.production_doi
@@ -160,41 +166,8 @@ class DepositionOrchestrator:
 
         # TODO (daz): stop using self.deposition_files, use the files lists on the depositions
         # Map file name to file metadata for all files in deposition
-        self.deposition_files = await self._remote_fileinfo(self.new_deposition)
-
-    # TODO (daz): inline this.
-    async def _remote_fileinfo(self, deposition: Deposition):
-        """Return info on all files contained in deposition.
-
-        Args:
-            deposition: Deposition for which to return file info.
-
-        Returns:
-            Dictionary mapping filenames to DepositionFile metadata objects.
-        """
-        return {f.filename: f for f in deposition.files}
-
-    # TODO (daz): inline this.
-    async def _create_deposition(self, data_source_id: str) -> Deposition:
-        """Create a Zenodo deposition resource.
-
-        This should only be called once for a given data source.  The deposition will be
-        prepared in draft form, so that files can be added prior to publication.
-
-        Args:
-            data_source_id: Data source ID that will be used to generate zenodo metadata
-            from data source metadata.
-
-        Returns:
-            Deposition object, per
-            https://developers.zenodo.org/?python#depositions
-        """
-        metadata = DepositionMetadata.from_data_source(data_source_id)
-        if not metadata.keywords:
-            raise AssertionError(
-                "New dataset is missing keywords and cannot be archived."
-            )
-        return await self.depositor.create_deposition(metadata)
+        self.deposition_files = {f.filename: f for f in self.new_deposition.files}
+        self.changes: list[_DepositionChange] = []
 
     async def run(self) -> RunSummary | Unchanged:
         """Run the entire deposition update process.
@@ -210,62 +183,45 @@ class DepositionOrchestrator:
         """
         await self._initialize()
 
+        resources = await self._upload_resources(self.downloader)
+        for deletion in self._get_deletions(resources):
+            await self._apply_change(deletion)
+
+        new_datapackage, old_datapackage = await self._update_datapackage(resources)
+        run_summary = self.downloader.generate_summary(
+            old_datapackage, new_datapackage, resources
+        )
+
+        if not self.changes:
+            # must run *after* updating datapackage.json
+            logger.info("No changes detected.")
+            await self.depositor.delete_deposition(self.new_deposition)
+            return Unchanged(dataset_name=self.data_source_id)
+
+        if not run_summary.success:
+            logger.error("Archive validation failed. Not publishing new archive.")
+            await self.depositor.delete_deposition(self.new_deposition)
+            return run_summary
+
+        await self._publish()
+
+        return run_summary
+
+    async def _upload_resources(
+        self, downloader: AbstractDatasetArchiver
+    ) -> dict[str, ResourceInfo]:
         resources = {}
-        changed = False
-        async for name, resource in self.downloader.download_all_resources():
+        async for name, resource in downloader.download_all_resources():
             resources[name] = resource
-            change = self._generate_changes(name, resource)
+            change = self._generate_change(name, resource)
             # Leave immediately after generating changes if dry_run
             if self.dry_run:
                 continue
             if change:
-                changed = True
                 await self._apply_change(change)
+        return resources
 
-        # Check for files that should no longer be in deposition
-        files_to_delete = self._get_files_to_delete(resources)
-        changed = changed or len(files_to_delete) > 0
-        if self.dry_run:
-            logger.info("Dry run, aborting")
-            return Unchanged(dataset_name=self.data_source_id, reason="Dry run.")
-
-        # Delete files no longer in deposition
-        [
-            await self._apply_change(
-                _DepositionChange(action_type=_DepositionAction.DELETE, name=name)
-            )
-            for name in files_to_delete
-        ]
-
-        self.new_deposition = await self.depositor.get_record(self.new_deposition.id_)
-        if changed:
-            # If there are any changes detected update datapackage and publish
-            new_datapackage, old_datapackage = await self._update_datapackage(resources)
-
-            run_summary = self.downloader.generate_summary(
-                old_datapackage, new_datapackage, resources
-            )
-            if not run_summary.success:
-                logger.error("Archive validation failed. Not publishing new archive.")
-                await self.depositor.delete_deposition(self.new_deposition)
-                return run_summary
-
-            if self.auto_publish:
-                published = await self.depositor.publish_deposition(self.new_deposition)
-                if self.create_new:
-                    self._update_dataset_settings(published)
-            else:
-                logger.info("Skipping publishing deposition to allow manual review.")
-                logger.info(
-                    f"Review new deposition at {self.new_deposition.links.html}"
-                )
-            return run_summary
-
-        logger.info("No changes detected.")
-        await self.depositor.delete_deposition(self.new_deposition)
-        return Unchanged(dataset_name=self.data_source_id)
-
-    def _generate_changes(
+    def _generate_change(
         self, name: str, resource: ResourceInfo
     ) -> _DepositionChange | None:
         action = None
@@ -292,18 +248,24 @@ class DepositionOrchestrator:
             resource=resource.local_path,
         )
 
-    def _get_files_to_delete(self, resources) -> list[str]:
+    def _get_deletions(self, resources) -> list[_DepositionChange]:
         # Delete files not included in new deposition
         files_to_delete = []
-        for filename, file_info in self.deposition_files.items():
+        for filename in self.deposition_files:
             if filename not in resources and filename != "datapackage.json":
                 logger.info(f"Deleting {filename} from deposition.")
-                files_to_delete.append(filename)
+                files_to_delete.append(
+                    _DepositionChange(_DepositionAction.DELETE, name=filename)
+                )
 
         return files_to_delete
 
     async def _apply_change(self, change: _DepositionChange):
         """Actually upload and delete what we listed in self.uploads/deletes."""
+        self.changes.append(change)
+        if self.dry_run:
+            logger.info(f"Dry run, skipping {change}")
+            return
         if change.action_type in [_DepositionAction.DELETE, _DepositionAction.UPDATE]:
             file_info = self.deposition_files[change.name]
             await self.depositor.delete_file(self.new_deposition, file_info.filename)
@@ -363,6 +325,7 @@ class DepositionOrchestrator:
         """
         if self.new_deposition is None:
             return None, None
+        self.new_deposition = await self.depositor.get_record(self.new_deposition.id_)
 
         logger.info(f"Creating new datapackage.json for {self.data_source_id}")
         files = {file.filename: file for file in self.new_deposition.files}
@@ -380,14 +343,6 @@ class DepositionOrchestrator:
             )
             response_bytes = await retry_async(response.read)
             old_datapackage = DataPackage.parse_raw(response_bytes)
-
-            # Stage old datapackge to be deleted
-            await self._apply_change(
-                _DepositionChange(
-                    action_type=_DepositionAction.DELETE,
-                    name="datapackage.json",
-                )
-            )
             files.pop("datapackage.json")
 
         # Create updated datapackage
@@ -402,12 +357,50 @@ class DepositionOrchestrator:
             bytes(datapackage.json(by_alias=True, indent=4), encoding="utf-8")
         )
 
-        await self._apply_change(
-            _DepositionChange(
-                action_type=_DepositionAction.CREATE,
-                name="datapackage.json",
-                resource=datapackage_json,
+        if old_datapackage is None:
+            await self._apply_change(
+                _DepositionChange(
+                    action_type=_DepositionAction.CREATE,
+                    name="datapackage.json",
+                    resource=datapackage_json,
+                )
             )
-        )
+        else:
+            if self._datapackage_worth_changing(old_datapackage, datapackage):
+                await self._apply_change(
+                    _DepositionChange(
+                        action_type=_DepositionAction.UPDATE,
+                        name="datapackage.json",
+                        resource=datapackage_json,
+                    )
+                )
 
         return datapackage, old_datapackage
+
+    def _datapackage_worth_changing(
+        self, old_datapackage: DataPackage, new_datapackage: DataPackage
+    ) -> bool:
+        # ignore differences in created/version
+        # ignore differences resource paths if it's just some ID number changing...
+        for field in new_datapackage.dict():
+            if field in {"created", "version"}:
+                continue
+            if field == "resources":
+                for r in old_datapackage.resources + new_datapackage.resources:
+                    r.path = re.sub(r"/\d+/", "/ID_NUMBER/", str(r.path))
+                    r.remote_url = re.sub(r"/\d+/", "/ID_NUMBER/", str(r.remote_url))
+            if getattr(new_datapackage, field) != getattr(old_datapackage, field):
+                return True
+        return False
+
+    async def _publish(self):
+        if self.dry_run:
+            logger.info("Dry run - not publishing at all.")
+            return
+        if self.auto_publish:
+            published = await self.depositor.publish_deposition(self.new_deposition)
+            if self.create_new:
+                self._update_dataset_settings(published)
+        else:
+            logger.info("Skipping publishing deposition to allow manual review.")
+            logger.info(f"Review new deposition at {self.new_deposition.links.html}")


### PR DESCRIPTION
Sometimes, e.g. when you've updated how you generate the `path` and `remote_url` fields of `datapackage.json`, you want to update `datapackage.json` EVEN THOUGH there were no changes to the files themselves.

Other times, you don't want to update `datapackage.json` because the difference between the old and new `datapackage.json` is just creation time / version number / deposition ID incrementing between the two versions.

Made some refactoring / cleanup changes while I was in here banging my head against how and when to do things:

* in-lined some very straightforward methods that were only being used in one place
* broke out helper functions from `run()` body to better communicate the flow of the orchestrator
* stopped bailing out immediately after changeset generation on dry run, in an attempt to allow dry-run to go through more of the logic. Unfortunately, datapackage creation is contingent on deposition state change on Zenodo (we want to get the path, remote_url, hash, and file-size to fully flesh out a `Resource` in a datapackage, and none of that is really captured in `ResourceInfo` so we get it from `DepositionFile`.) - so `--dry-run` now dumps a bunch of silliness into the summary file. I wonder if we even still need it now that `--auto-publish` defaults to `False`.

Also, did some funny stuff in test:
* sometimes Zenodo is fine with trying to download the "canonical" URL... that they told us about... other times it throws a tantrum (i.e., 500 error), and refuses to accept anything but the `file.links.download` link. So I changed the test "download a file to verify its contents" method to handle both 🙄 
* added another scenario in the mega-integration test that patches out the canonical URL to something silly to check that datapackage.json does, in fact, get updated

Finally, I did the following to test manually:
1.`pudl_archiver --datasets eia861 --summary-file eia861-summary.json --sandbox` - the resources in the old `datapackage.json` were empty, so this updated the sandbox version to a fully well-formed archive.
2. publish manually,
3. run `pudl_archiver --datasets eia861 --summary-file eia861-summary.json --sandbox` again - got "No changes detected".
4. update the `FileLinks.canonical()` method to append `"bogus"` to each canonical URL.
5. Re-run `pudl_archiver --datasets eia861 --summary-file eia861-summary.json --sandbox` - now I see that the new version has the new datapackage.json. The run summary shows no file changes, as expected
6. delete the bogus draft to avoid confusion.


There's still some stuff I'd like to clean up, but I figured that is going out of the scope of "make it so that we can publish a `datapackage.json`-only change to Zenodo."
* The `Unchanged`/`RunSummary` split seems like it introduces more complexity than it removes - A RunSummary summarizes the changes in a run, and it's easy to check if `file_changes` is empty
* I'd love to be able to generate the `datapackage.json` from just `resources` dictionary so that the dry-run outputs a better summary