### PR TITLE
Allow integers and lists for partition pydantic validation, fix PHMSA bug

### DIFF
--- a/src/pudl_archiver/archivers/phmsagas.py
+++ b/src/pudl_archiver/archivers/phmsagas.py
@@ -80,8 +80,8 @@ class PhmsaGasArchiver(AbstractDatasetArchiver):
         start_year = int(filename.split("_")[-2])
         end_year = filename.split("_")[-1]
         # If end year is present, this will include data through last year.
-        end_year = datetime.now().year if end_year == "present" else int(end_year)
-        years = list(range(start_year, end_year))
+        end_year = datetime.now().year - 1 if end_year == "present" else int(end_year)
+        years = list(range(start_year, end_year + 1))
 
         download_path = self.download_directory / f"{self.name}-{filename}.zip"
         await self.download_zipfile(url, download_path)

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -88,8 +88,8 @@ class PartitionDiff(BaseModel):
     """Model summarizing changes in partitions."""
 
     key: Any = None
-    value: str | None = None
-    previous_value: str | None = None
+    value: str | int | list[str | int] | None = None
+    previous_value: str | int | list[str | int] | None = None
     diff_type: Literal["CREATE", "UPDATE", "DELETE"]
 
 


### PR DESCRIPTION
With PHMSA, we use both integers (former) and lists of integers (current) as our partitions. This breaks the existing checks on `PartitionDiff`. This tiny PR allows more types for partitions.

Also fixes incorrect year range on the PHMSA archiver - `present` files should point to last year's data, while `_2003` should contain data up until 2003, e.g.