### PR TITLE
Push some state to `orchestrator.run()`

### DIFF
--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -82,7 +82,7 @@ async def archive_datasets(
                 session,
                 upload_key,
                 publish_key,
-                deposition_settings=Path("dataset_doi.yaml"),
+                dataset_settings_path=Path("dataset_doi.yaml"),
                 create_new=initialize,
                 dry_run=dry_run,
                 sandbox=sandbox,

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -157,7 +157,7 @@ class DataPackage(BaseModel):
         name: str,
         files: Iterable[DepositionFile],
         resources: dict[str, ResourceInfo],
-        version: str,
+        version: str | None,
     ) -> "DataPackage":
         """Create a frictionless datapackage from a list of files and partitions.
 

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -91,7 +91,7 @@ class DepositionOrchestrator:
         session: aiohttp.ClientSession,
         upload_key: str,
         publish_key: str,
-        deposition_settings: Path,
+        dataset_settings_path: Path,
         create_new: bool = False,
         dry_run: bool = True,
         sandbox: bool = True,
@@ -106,7 +106,7 @@ class DepositionOrchestrator:
             session: Async http client session manager.
             upload_key: Zenodo API upload key.
             publish_key: Zenodo API publish key.
-            deposition_settings: where the various production/sandbox concept
+            dataset_settings_path: where the various production/sandbox concept
                 DOIs are stored.
             create_new: whether or not we are initializing a new Zenodo Concept DOI.
             dry_run: Whether or not we upload files to Zenodo in this run.
@@ -134,8 +134,8 @@ class DepositionOrchestrator:
         self.dry_run = dry_run
 
         self.create_new = create_new
-        self.dataset_settings_path = deposition_settings
-        with Path.open(deposition_settings) as f:
+        self.dataset_settings_path = dataset_settings_path
+        with Path.open(dataset_settings_path) as f:
             self.dataset_settings = {
                 name: DatasetSettings(**dois)
                 for name, dois in yaml.safe_load(f).items()

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -108,11 +108,6 @@ class DepositionOrchestrator:
         Returns:
             DepositionOrchestrator
         """
-        if sandbox:
-            self.api_root = "https://sandbox.zenodo.org/api"
-        else:
-            self.api_root = "https://zenodo.org/api"
-
         self.sandbox = sandbox
         self.data_source_id = data_source_id
 
@@ -342,7 +337,9 @@ class DepositionOrchestrator:
         """
         if self.new_deposition is None:
             return None, None
-        self.new_deposition = await self.depositor.get_record(self.new_deposition.id_)
+        self.new_deposition = await self.depositor.get_deposition_by_id(
+            self.new_deposition.id_
+        )
 
         logger.info(f"Creating new datapackage.json for {self.data_source_id}")
         files = {file.filename: file for file in self.new_deposition.files}

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -15,7 +15,7 @@ from pudl_archiver.archivers.classes import AbstractDatasetArchiver
 from pudl_archiver.archivers.validate import RunSummary
 from pudl_archiver.depositors import ZenodoDepositor
 from pudl_archiver.frictionless import DataPackage, ResourceInfo
-from pudl_archiver.utils import retry_async
+from pudl_archiver.utils import Url, retry_async
 from pudl_archiver.zenodo.entities import (
     Deposition,
     DepositionFile,
@@ -101,9 +101,18 @@ class DepositionOrchestrator:
 
         Args:
             data_source_id: Data source ID.
+            downloader: AbstractDatasetArchiver that actually handles the data
+                downloads.
             session: Async http client session manager.
             upload_key: Zenodo API upload key.
             publish_key: Zenodo API publish key.
+            deposition_settings: where the various production/sandbox concept
+                DOIs are stored.
+            create_new: whether or not we are initializing a new Zenodo Concept DOI.
+            dry_run: Whether or not we upload files to Zenodo in this run.
+            sandbox: Whether or not we are in a sandbox environment
+            auto_publish: Whether we automatically publish the draft when we're
+                done, vs. letting a human approve of it.
 
         Returns:
             DepositionOrchestrator
@@ -122,45 +131,34 @@ class DepositionOrchestrator:
         self.depositor = ZenodoDepositor(upload_key, publish_key, session, self.sandbox)
         self.downloader = downloader
 
-        # TODO (daz): don't hold references to the depositions at the instance level.
-        self.deposition: Deposition | None = None
-        self.new_deposition: Deposition | None = None
-        self.deposition_files: dict[str, DepositionFile] = {}
-
         self.dry_run = dry_run
 
         self.create_new = create_new
-        self.deposition_settings = deposition_settings
+        self.dataset_settings_path = deposition_settings
         with Path.open(deposition_settings) as f:
             self.dataset_settings = {
                 name: DatasetSettings(**dois)
                 for name, dois in yaml.safe_load(f).items()
             }
 
-    async def _initialize(self):
-        if self.create_new:
-            doi = None
-            metadata = DepositionMetadata.from_data_source(self.data_source_id)
-            if not metadata.keywords:
-                raise AssertionError(
-                    "New dataset is missing keywords and cannot be archived."
-                )
-            self.deposition = await self.depositor.create_deposition(metadata)
-        else:
-            settings = self.dataset_settings[self.data_source_id]
-            doi = settings.sandbox_doi if self.sandbox else settings.production_doi
-            if not doi:
-                raise RuntimeError("Must pass a valid DOI if create_new is False")
-
-            self.deposition = await self.depositor.get_deposition(doi)
-        self.new_deposition = await self.depositor.get_new_version(
-            self.deposition, clobber=not self.create_new
-        )
-
-        # TODO (daz): stop using self.deposition_files, use the files lists on the depositions
-        # Map file name to file metadata for all files in deposition
-        self.deposition_files = {f.filename: f for f in self.new_deposition.files}
         self.changes: list[_DepositionChange] = []
+
+    async def _create_new_deposition(self) -> Deposition:
+        metadata = DepositionMetadata.from_data_source(self.data_source_id)
+        if not metadata.keywords:
+            raise AssertionError(
+                "New dataset is missing keywords and cannot be archived."
+            )
+        return await self.depositor.create_deposition(metadata)
+
+    async def _get_existing_deposition(
+        self, dataset_settings: dict[str, DatasetSettings], data_source_id: str
+    ) -> Deposition:
+        settings = dataset_settings[data_source_id]
+        doi = settings.sandbox_doi if self.sandbox else settings.production_doi
+        if not doi:
+            raise RuntimeError("Must pass a valid DOI if create_new is False")
+        return await self.depositor.get_deposition(doi)
 
     async def run(self) -> RunSummary:
         """Run the entire deposition update process.
@@ -174,38 +172,52 @@ class DepositionOrchestrator:
         Returns:
             RunSummary object.
         """
-        await self._initialize()
+        self.changes = []
+        if self.create_new:
+            original = await self._create_new_deposition()
+            draft = original
+        else:
+            original = await self._get_existing_deposition(
+                self.dataset_settings, self.data_source_id
+            )
+            draft = await self.depositor.get_new_version(original, clobber=True)
 
-        resources = await self._download_then_upload_resources(self.downloader)
-        for deletion in self._get_deletions(resources):
-            await self._apply_change(deletion)
+        resources = await self._download_then_upload_resources(draft, self.downloader)
+        for deletion in self._get_deletions(draft, resources):
+            await self._apply_change(draft, deletion)
 
-        new_datapackage, old_datapackage = await self._update_datapackage(resources)
-        run_summary = self._summarize_run(old_datapackage, new_datapackage, resources)
+        draft = await self.depositor.get_deposition_by_id(draft.id_)
+        new_datapackage, old_datapackage = await self._update_datapackage(
+            draft, resources
+        )
+        run_summary = self._summarize_run(
+            old_datapackage, new_datapackage, resources, draft.links.html
+        )
 
         if not self.changes:
             # must run *after* potentially updating datapackage.json
             logger.info(
-                "No changes detected, kept draft at "
-                f"{self.new_deposition.links.html} for inspection."
+                f"No changes detected, kept draft at {draft.links.html} for "
+                "inspection."
             )
             return run_summary
 
         if not run_summary.success:
             logger.error(
                 "Archive validation failed. Not publishing new archive, kept "
-                f"draft at {self.new_deposition.links.html} for inspection."
+                f"draft at {draft.links.html} for inspection."
             )
             return run_summary
 
-        await self._publish()
+        await self._publish(draft)
         return run_summary
 
     def _summarize_run(
         self,
-        old_datapackage: DataPackage,
+        old_datapackage: DataPackage | None,
         new_datapackage: DataPackage,
         resources: dict[str, ResourceInfo],
+        draft_url: Url,
     ) -> RunSummary:
         validations = self.downloader.validate_dataset(
             old_datapackage, new_datapackage, resources
@@ -216,33 +228,33 @@ class DepositionOrchestrator:
             old_datapackage,
             new_datapackage,
             validations,
-            record_url=self.new_deposition.links.html,
+            record_url=draft_url,
         )
 
     async def _download_then_upload_resources(
-        self, downloader: AbstractDatasetArchiver
+        self, draft: Deposition, downloader: AbstractDatasetArchiver
     ) -> dict[str, ResourceInfo]:
         resources = {}
         async for name, resource in downloader.download_all_resources():
             resources[name] = resource
-            change = self._generate_change(name, resource)
+            change = self._generate_change(name, resource, draft.files_map)
             # Leave immediately after generating changes if dry_run
             if self.dry_run:
                 continue
             if change:
-                await self._apply_change(change)
+                await self._apply_change(draft, change)
         return resources
 
     def _generate_change(
-        self, name: str, resource: ResourceInfo
+        self, name: str, resource: ResourceInfo, files: dict[str, DepositionFile]
     ) -> _DepositionChange | None:
         action = None
-        if name not in self.deposition_files:
+        if name not in files:
             logger.info(f"Adding {name} to deposition.")
 
             action = _DepositionAction.CREATE
         else:
-            file_info = self.deposition_files[name]
+            file_info = files[name]
 
             # If file is not exact match for existing file, update with new file
             if (local_md5 := _compute_md5(resource.local_path)) != file_info.checksum:
@@ -260,10 +272,12 @@ class DepositionOrchestrator:
             resource=resource.local_path,
         )
 
-    def _get_deletions(self, resources) -> list[_DepositionChange]:
+    def _get_deletions(
+        self, draft: Deposition, resources: dict[str, ResourceInfo]
+    ) -> list[_DepositionChange]:
         # Delete files not included in new deposition
         files_to_delete = []
-        for filename in self.deposition_files:
+        for filename in draft.files_map:
             if filename not in resources and filename != "datapackage.json":
                 logger.info(f"Deleting {filename} from deposition.")
                 files_to_delete.append(
@@ -272,31 +286,36 @@ class DepositionOrchestrator:
 
         return files_to_delete
 
-    async def _apply_change(self, change: _DepositionChange):
-        """Actually upload and delete what we listed in self.uploads/deletes."""
+    async def _apply_change(self, draft: Deposition, change: _DepositionChange) -> None:
+        """Actually upload and delete what we listed in self.uploads/deletes.
+
+        Args:
+            draft: the draft to make these changes to
+            change: the change to make
+        """
         self.changes.append(change)
         if self.dry_run:
             logger.info(f"Dry run, skipping {change}")
             return
         if change.action_type in [_DepositionAction.DELETE, _DepositionAction.UPDATE]:
-            file_info = self.deposition_files[change.name]
-            await self.depositor.delete_file(self.new_deposition, file_info.filename)
+            file_info = draft.files_map[change.name]
+            await self.depositor.delete_file(draft, file_info.filename)
         if change.action_type in [_DepositionAction.CREATE, _DepositionAction.UPDATE]:
             if change.resource is None:
                 raise RuntimeError("Must pass a resource to be uploaded.")
 
             await self._upload_file(
-                _UploadSpec(source=change.resource, dest=change.name)
+                draft, _UploadSpec(source=change.resource, dest=change.name)
             )
 
-    async def _upload_file(self, upload: _UploadSpec):
+    async def _upload_file(self, draft: Deposition, upload: _UploadSpec):
         if isinstance(upload.source, io.IOBase):
             wrapped_file = FileWrapper(upload.source.read())
         else:
             with upload.source.open("rb") as f:
                 wrapped_file = FileWrapper(f.read())
 
-        await self.depositor.create_file(self.new_deposition, upload.dest, wrapped_file)
+        await self.depositor.create_file(draft, upload.dest, wrapped_file)
 
         wrapped_file.actually_close()
 
@@ -319,35 +338,33 @@ class DepositionOrchestrator:
         )
 
         # Update doi settings YAML
-        with Path.open(self.deposition_settings, "w") as f:
+        with Path.open(self.dataset_settings_path, "w") as f:
             raw_settings = {
                 name: settings.dict()
                 for name, settings in self.dataset_settings.items()
             }
             yaml.dump(raw_settings, f)
 
-    async def _update_datapackage(self, resources: dict[str, ResourceInfo]):
+    async def _update_datapackage(
+        self,
+        draft: Deposition,
+        resources: dict[str, ResourceInfo],
+    ) -> tuple[DataPackage, DataPackage | None]:
         """Create new frictionless datapackage for deposition.
 
         Args:
+            draft: the draft we're trying to describe
             resources: Dictionary mapping resources to ResourceInfo which is used to
-            generate new datapackage
+            generate new datapackage - we need this for the partition information.
+
         Returns:
-            Updated Deposition.
+            new DataPackage, old DataPackage
         """
-        if self.new_deposition is None:
-            return None, None
-        self.new_deposition = await self.depositor.get_deposition_by_id(
-            self.new_deposition.id_
-        )
-
         logger.info(f"Creating new datapackage.json for {self.data_source_id}")
-        files = {file.filename: file for file in self.new_deposition.files}
-
         old_datapackage = None
-        if "datapackage.json" in files:
-            # Download old datapackage
-            url = files["datapackage.json"].links.download
+        if "datapackage.json" in draft.files_map:
+            # Download old datapackage - we haven't updated it yet.
+            url = draft.files_map["datapackage.json"].links.download
             response = await self.depositor.request(
                 "GET",
                 url,
@@ -357,14 +374,14 @@ class DepositionOrchestrator:
             )
             response_bytes = await retry_async(response.read)
             old_datapackage = DataPackage.parse_raw(response_bytes)
-            files.pop("datapackage.json")
+            draft.files_map.pop("datapackage.json")
 
         # Create updated datapackage
         datapackage = DataPackage.from_filelist(
             self.data_source_id,
-            files.values(),
+            [f for f in draft.files if f.filename != "datapackage.json"],
             resources,
-            self.new_deposition.metadata.version,
+            draft.metadata.version,
         )
 
         datapackage_json = io.BytesIO(
@@ -375,20 +392,22 @@ class DepositionOrchestrator:
 
         if old_datapackage is None:
             await self._apply_change(
+                draft,
                 _DepositionChange(
                     action_type=_DepositionAction.CREATE,
                     name="datapackage.json",
                     resource=datapackage_json,
-                )
+                ),
             )
         else:
             if self._datapackage_worth_changing(old_datapackage, datapackage):
                 await self._apply_change(
+                    draft,
                     _DepositionChange(
                         action_type=_DepositionAction.UPDATE,
                         name="datapackage.json",
                         resource=datapackage_json,
-                    )
+                    ),
                 )
 
         return datapackage, old_datapackage
@@ -409,14 +428,14 @@ class DepositionOrchestrator:
                 return True
         return False
 
-    async def _publish(self):
+    async def _publish(self, draft: Deposition) -> None:
         if self.dry_run:
             logger.info("Dry run - not publishing at all.")
             return
         if self.auto_publish:
-            published = await self.depositor.publish_deposition(self.new_deposition)
+            published = await self.depositor.publish_deposition(draft)
             if self.create_new:
                 self._update_dataset_settings(published)
         else:
             logger.info("Skipping publishing deposition to allow manual review.")
-            logger.info(f"Review new deposition at {self.new_deposition.links.html}")
+            logger.info(f"Review new deposition at {draft.links.html}")

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -196,6 +196,11 @@ class Deposition(BaseModel):
     submitted: bool
     title: str
 
+    @property
+    def files_map(self) -> dict[str, DepositionFile]:
+        """Files associated with their filenames."""
+        return {f.filename: f for f in self.files}
+
 
 class Record(BaseModel):
     """The /records/ endpoints return a slightly different data structure."""

--- a/src/pudl_archiver/zenodo/entities.py
+++ b/src/pudl_archiver/zenodo/entities.py
@@ -195,3 +195,10 @@ class Deposition(BaseModel):
     state: Literal["inprogress", "done", "error", "submitted", "unsubmitted"]
     submitted: bool
     title: str
+
+
+class Record(BaseModel):
+    """The /records/ endpoints return a slightly different data structure."""
+
+    id_: int = Field(alias="id")
+    links: DepositionLinks

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 from pudl.metadata.classes import DataSource
 from pudl.metadata.constants import LICENSES
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver, ResourceInfo
+from pudl_archiver.archivers.validate import RunSummary
 from pudl_archiver.orchestrator import DepositionOrchestrator
 from pudl_archiver.zenodo.entities import (
     Deposition,
@@ -168,6 +169,10 @@ async def test_zenodo_workflow(
             # Verify that contents of file are correct
             assert res.text.encode() == file_data["contents"]
 
+    async def refresh_record_info(run_summary: RunSummary) -> Deposition:
+        record_id = run_summary.record_url.path.rsplit("/", maxsplit=1)[1]
+        return await orchestrator.depositor.get_deposition_by_id(record_id)
+
     deposition_interface_args = {
         "data_source_id": "pudl_test",
         "session": session,
@@ -227,9 +232,7 @@ async def test_zenodo_workflow(
     v1_summary = await orchestrator.run()
     assert v1_summary.success
 
-    v1_refreshed = await orchestrator.depositor.get_deposition_by_id(
-        orchestrator.new_deposition.id_
-    )
+    v1_refreshed = await refresh_record_info(v1_summary)
     verify_files(test_files["original"], v1_refreshed)
 
     # the /records/ URL doesn't work until the record is published, but
@@ -266,9 +269,7 @@ async def test_zenodo_workflow(
     v2_summary = await orchestrator.run()
     assert v2_summary.success
 
-    v2_refreshed = await orchestrator.depositor.get_deposition_by_id(
-        orchestrator.new_deposition.id_
-    )
+    v2_refreshed = await refresh_record_info(v2_summary)
     verify_files(test_files["updated"], v2_refreshed)
 
     # try keeping everything the same except the canonical URL - should trigger a datapackage.json-only change
@@ -279,10 +280,7 @@ async def test_zenodo_workflow(
     assert len(v3_summary.file_changes) == 0
     assert len(orchestrator.changes) == 1
 
-    v3_refreshed = await orchestrator.depositor.get_deposition_by_id(
-        orchestrator.new_deposition.id_
-    )
-
+    v3_refreshed = await refresh_record_info(v3_summary)
     # no updates to make, should not leave the conceptdoi pointing at a draft
     v4_summary = await orchestrator.run()
     assert len(v4_summary.file_changes) == 0

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -227,7 +227,7 @@ async def test_zenodo_workflow(
     v1_summary = await orchestrator.run()
     assert v1_summary.success
 
-    v1_refreshed = await orchestrator.depositor.get_record(
+    v1_refreshed = await orchestrator.depositor.get_deposition_by_id(
         orchestrator.new_deposition.id_
     )
     verify_files(test_files["original"], v1_refreshed)
@@ -266,7 +266,7 @@ async def test_zenodo_workflow(
     v2_summary = await orchestrator.run()
     assert v2_summary.success
 
-    v2_refreshed = await orchestrator.depositor.get_record(
+    v2_refreshed = await orchestrator.depositor.get_deposition_by_id(
         orchestrator.new_deposition.id_
     )
     verify_files(test_files["updated"], v2_refreshed)
@@ -279,7 +279,7 @@ async def test_zenodo_workflow(
     assert len(v3_summary.file_changes) == 0
     assert len(orchestrator.changes) == 1
 
-    v3_refreshed = await orchestrator.depositor.get_record(
+    v3_refreshed = await orchestrator.depositor.get_deposition_by_id(
         orchestrator.new_deposition.id_
     )
 

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -178,7 +178,7 @@ async def test_zenodo_workflow(
         "session": session,
         "upload_key": upload_key,
         "publish_key": publish_key,
-        "deposition_settings": test_settings,
+        "dataset_settings_path": test_settings,
         "dry_run": False,
         "sandbox": True,
         "auto_publish": True,


### PR DESCRIPTION
We talked a big game about wanting to stop using `self.deposition`, `self.new_deposition` everywhere.

It wasn't such a bad change in the end!

In the future I think we can try to split up the concept of a "Zenodo `Deposition`" (the API response object) from a "PUDL Dataset Version" (some sort of concept that *we* have). That could look something like:

```python
class DatasetVersion:
    rec_id: int
    ...

class PublishedDataset:
    def from_doi(concept_doi) -> PublishedDataset:
       ...

    def get_draft_version(self) -> DraftDataset:
        # call Zenodo API here, maybe cry a little bit?

class DraftDataset(Dataset):
    def sync_with_resources(self, resources) -> DraftDataset:
        # call Zenodo API here, or we call the New Zenodo API here, whatever

# maybe some other states too - could see "completed" vs. "in-progress" drafts being a useful distinction

# in orchestrator.run...
original = PublishedDataset.from_doi(doi)
draft = original.get_draft_version()
draft.sync_with_resources()
```

That would make the `ZenodoDepositor` much more of a "thin shell around literal API calls" and the "convert operations that *we* care about into operations that *Zenodo* cares about" messiness would live in the various subclasses of `Dataset`.

I think we almost got to this level of abstraction with the last big refactor we did, but stopped short - so we never separated "the set of operations we care about doing to a dataset version" from "the set of operations that Zenodo knows how to do" cleanly.

I *might* try to get that restructuring in ahead of time, before the next Zenodo API change happens. Maybe we can even experiment with archiving to multiple RDMs...