### PR TITLE
Point automated archiver at production Zenodo.

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -51,7 +51,7 @@ jobs:
           ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
           ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         run: |
-          pudl_archiver --sandbox --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
+          pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
 
       - name: Upload run summaries
         id: upload_summaries


### PR DESCRIPTION
Closes catalyst-cooperative/pudl#3068.

Now that we have automatically running archivers that send stuff to Slack when they succeed/fail and point us towards places we can actually approve them, we should point these at production!