### PR TITLE
Don't do a weird song-and-dance to guarantee a fresh draft.

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -6,7 +6,7 @@ eia176:
   sandbox_doi: 10.5072/zenodo.3158
 eia860:
   production_doi: 10.5281/zenodo.4127026
-  sandbox_doi: 10.5072/zenodo.3299
+  sandbox_doi: 10.5072/zenodo.11168
 eia860m:
   production_doi: 10.5281/zenodo.4281336
   sandbox_doi: 10.5072/zenodo.3172
@@ -27,7 +27,7 @@ epacamd_eia:
   sandbox_doi: 10.5072/zenodo.3136
 epacems:
   production_doi: 10.5281/zenodo.10233185
-  sandbox_doi: 10.5072/zenodo.2236
+  sandbox_doi: 10.5072/zenodo.9811
 ferc1:
   production_doi: 10.5281/zenodo.4127043
   sandbox_doi: 10.5072/zenodo.3267

--- a/src/pudl_archiver/archivers/epacems.py
+++ b/src/pudl_archiver/archivers/epacems.py
@@ -44,6 +44,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
                 and (self.valid_year(file["metadata"]["year"]))
             ]
             logger.info(f"Downloading {len(quarterly_emissions_files)} total files.")
+            logger.debug(f"File info: {quarterly_emissions_files}")
             for i, cems_file in enumerate(quarterly_emissions_files):
                 yield self.get_year_quarter_resource(
                     file=cems_file, request_count=i + 1
@@ -69,7 +70,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
         quarter = file["metadata"]["quarter"]
 
         # Useful to debug at download time-outs.
-        logger.debug(f"Downloading {year} Q{quarter} EPACEMS data.")
+        logger.info(f"Downloading {year} Q{quarter} EPACEMS data from {url}.")
 
         # Create zipfile to store year/quarter combinations of files
         filename = f"epacems-{year}-{quarter}.csv"

--- a/src/pudl_archiver/depositors/zenodo.py
+++ b/src/pudl_archiver/depositors/zenodo.py
@@ -224,91 +224,42 @@ class ZenodoDepositor:
             A new Deposition that is a snapshot of the old one you passed in,
             with a new major version number.
         """
-        # if this is a draft, either this is a potentially dirty draft (in
-        # which case, delete it) - or, this is the first deposition of a
-        # concept and we should just return it unharmed.
-        if not deposition.submitted:
-            if clobber:
-                await self.delete_deposition(deposition)
-                deposition = await self.get_deposition(str(deposition.conceptdoi))
-            else:
-                return deposition
-
-        url = f"{self.api_root}/deposit/depositions/{deposition.id_}/actions/newversion"
-
-        # create a new unpublished deposition version
-        try:
-            response = await self.request(
+        # just get the new draft from new API.
+        new_draft_record = Record(
+            **await self.request(
                 "POST",
-                url,
-                log_label="Creating new version",
-                headers=self.auth_write,
-                retry_count=2,
-            )
-        # Except if abandoned in progress draft
-        except ZenodoClientError as excinfo:
-            if (
-                clobber
-                and "remove all files first" in excinfo.errors[0]["messages"][0].lower()
-            ):
-                logger.info("Delete abandoned version and create new one.")
-                existing_deposition = await self.get_deposition(
-                    str(deposition.conceptdoi)
-                )
-                new_draft = Record(
-                    **await self.request(
-                        "POST",
-                        f"{self.api_root}/records/{existing_deposition.id_}/versions",
-                        log_label=f"Get existing draft deposition for {existing_deposition.id_}",
-                        headers=self.auth_write,
-                    )
-                )
-                await self.request(
-                    "DELETE",
-                    new_draft.links.self,
-                    log_label=f"Delete existing draft deposition for {existing_deposition.id_}",
-                    headers=self.auth_write,
-                    parse_json=False,
-                )
-            response = await self.request(
-                "POST",
-                url,
-                log_label="Creating new version",
+                f"{self.api_root}/records/{deposition.id_}/versions",
+                log_label=f"Get existing draft deposition for {deposition.id_}",
                 headers=self.auth_write,
             )
-
-        old_metadata = deposition.metadata.dict(by_alias=True)
-        new_version = Deposition(**response)
-
-        source_metadata = new_version.metadata.dict(by_alias=True)
-
-        # If version not in response for new version, get from most recent deposition
-        if source_metadata["version"] is None:
-            source_metadata["version"] = old_metadata["version"]
-
-        metadata = {}
-        for key, val in source_metadata.items():
-            if key not in ["doi", "prereserve_doi", "publication_date"]:
-                metadata[key] = val
-
-        previous = semantic_version.Version(source_metadata["version"])
-        version_info = previous.next_major()
-
-        metadata["version"] = str(version_info)
+        )
+        # then, get the deposition based on that ID.
+        new_draft_deposition = await self.get_deposition_by_id(new_draft_record.id_)
 
         # Update metadata of new deposition with new version info
+        base_metadata = deposition.metadata.model_dump(by_alias=True)
+        draft_metadata = new_draft_deposition.metadata.model_dump(by_alias=True)
+        metadata = {
+            key: val
+            for key, val in (base_metadata | draft_metadata).items()
+            if key not in {"doi", "prereserve_doi", "publication_date"}
+        }
+        base_version = semantic_version.Version(base_metadata["version"])
+        new_version = base_version.next_major()
+        metadata["version"] = str(new_version)
+        logging.info(f"{base_metadata=}\n{draft_metadata=}\n{metadata=}")
         data = json.dumps({"metadata": metadata})
-
         # Get url to newest deposition
-        new_deposition_url = new_version.links.latest_draft
+        new_deposition_url = new_draft_deposition.links.latest_draft
         headers = {
             "Content-Type": "application/json",
         } | self.auth_write
-
         response = await self.request(
             "PUT",
             new_deposition_url,
-            log_label=f"Updating version number from {previous} ({new_version.id_}) to {version_info}",
+            log_label=f"Updating version number from {base_version} "
+            f"(from {deposition.id_}) to {new_version} "
+            f"(on {new_draft_deposition.id_})",
             data=data,
             headers=headers,
         )


### PR DESCRIPTION
As part of #230 I found that we were running into flakiness when deleting drafts and re-creating them to guarantee a fresh starting state for our archiver - i.e., one where the new draft matches the existing deposition exactly.

But, I realized that we don't need to guarantee a fresh starting state and can ditch a lot of that logic - and the less logic we have that tries to deal with Zenodo state, the less that instability in that behavior will affect us 🥲 

This doesn't fix #230 completely, because we seem to also sometimes fail to download from CEMS, but should improve our Zenodo interaction somewhat.