### PR TITLE
Zip EIA 860M files by year

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -9,7 +9,7 @@ eia860:
   sandbox_doi: 10.5072/zenodo.11168
 eia860m:
   production_doi: 10.5281/zenodo.4281336
-  sandbox_doi: 10.5072/zenodo.3172
+  sandbox_doi: 10.5072/zenodo.13855
 eia861:
   production_doi: 10.5281/zenodo.4127028
   sandbox_doi: 10.5072/zenodo.1441

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -188,6 +188,21 @@ class AbstractDatasetArchiver(ABC):
         ) as archive:
             archive.writestr(filename, response_bytes)
 
+    def add_to_archive(self, target_archive: Path, name: str, blob: typing.BinaryIO):
+        """Add a file to a ZIP archive.
+
+        Args:
+            target_archive: path to target archive.
+            name: name of the file *within* the archive.
+            blob: the content you'd like to write to the archive.
+        """
+        with zipfile.ZipFile(
+            target_archive,
+            "a",
+            compression=zipfile.ZIP_DEFLATED,
+        ) as archive:
+            archive.writestr(name, blob.read())
+
     async def get_hyperlinks(
         self,
         url: str,

--- a/src/pudl_archiver/archivers/eia860.py
+++ b/src/pudl_archiver/archivers/eia860.py
@@ -1,6 +1,5 @@
 """Download EIA-860 data."""
 import re
-from pathlib import Path
 
 from pudl_archiver.archivers.classes import (
     AbstractDatasetArchiver,
@@ -20,11 +19,14 @@ class Eia860Archiver(AbstractDatasetArchiver):
         """Download EIA-860 resources."""
         link_pattern = re.compile(r"eia860(\d{4})(ER)*.zip")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
-            year = int(link_pattern.search(link).group(1))
+            matches = link_pattern.search(link)
+            if not matches:
+                continue
+            year = int(matches.group(1))
             if self.valid_year(year):
                 yield self.get_year_resource(link, year)
 
-    async def get_year_resource(self, link: str, year: int) -> tuple[Path, dict]:
+    async def get_year_resource(self, link: str, year: int) -> ResourceInfo:
         """Download zip file."""
         # Append hyperlink to base URL to get URL of file
         url = f"{BASE_URL}/{link}"

--- a/src/pudl_archiver/archivers/eia860m.py
+++ b/src/pudl_archiver/archivers/eia860m.py
@@ -1,13 +1,14 @@
 """Download EIA-860M data."""
 import calendar
 import re
-from pathlib import Path
+from collections import defaultdict
 
 from pudl_archiver.archivers.classes import (
     AbstractDatasetArchiver,
     ArchiveAwaitable,
     ResourceInfo,
 )
+from pudl_archiver.frictionless import ZipLayout
 
 BASE_URL = "https://www.eia.gov/electricity/data/eia860m"
 
@@ -24,21 +25,44 @@ class Eia860MArchiver(AbstractDatasetArchiver):
         """Download EIA-860M resources."""
         link_pattern = re.compile(r"([a-z]+)_generator(\d{4}).xlsx")
 
+        year_links: dict[int, dict[int, str]] = defaultdict(dict)
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
             match = link_pattern.search(link)
+            if not match:
+                continue
             year = int(match.group(2))
             month = self.month_map[match.group(1)]
             if self.valid_year(year):
-                yield self.get_year_month_resource(link, year, month)
+                year_links[year][month] = link
 
-    async def get_year_month_resource(
-        self, link: str, year: int, month: int
-    ) -> tuple[Path, dict]:
+        for year, month_links in year_links.items():
+            yield self.get_year_resource(year, month_links)
+
+    async def get_year_resource(
+        self, year: int, month_links: dict[int, str]
+    ) -> ResourceInfo:
         """Download xlsx file."""
-        url = f"https://eia.gov/{link}"
-        download_path = self.download_directory / f"eia860m-{year}-{month:02}.xlsx"
-        await self.download_file(url, download_path)
+        archive_path = self.download_directory / f"eia860m-{year}.zip"
+        data_paths_in_archive = set()
+        for month, link in sorted(month_links.items()):
+            url = f"https://eia.gov/{link}"
+            name = f"eia860m-{year}-{month:02}.xlsx"
+            download_path = self.download_directory / name
+            await self.download_file(url, download_path)
+            self.add_to_archive(
+                target_archive=archive_path,
+                name=name,
+                blob=download_path.open("rb"),
+            )
+            data_paths_in_archive.add(name)
+            # Don't want to leave multiple giant CSVs on disk, so delete
+            # immediately after they're safely stored in the ZIP
+            download_path.unlink()
 
         return ResourceInfo(
-            local_path=download_path, partitions={"year_month": f"{year}-{month:02}"}
+            local_path=archive_path,
+            partitions={
+                "year_month": sorted([f"{year}-{month:02}" for month in month_links])
+            },
+            layout=ZipLayout(file_paths=data_paths_in_archive),
         )

--- a/tests/unit/eia_archiver_test.py
+++ b/tests/unit/eia_archiver_test.py
@@ -50,7 +50,7 @@ async def test_eia860m(mocker):
     )
     archiver = Eia860MArchiver(mock_session, only_years=[2019, 2022])
     resources = [res async for res in archiver.get_resources()]
-    assert len(resources) == 24
+    assert len(resources) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/eia_archiver_test.py
+++ b/tests/unit/eia_archiver_test.py
@@ -23,7 +23,7 @@ async def test_eia860(mocker):
 
 
 @pytest.mark.asyncio
-async def test_eia860m(mocker):
+async def test_eia860m(mocker, tmp_path):
     mock_session = mocker.AsyncMock()
     urls = [
         f"https://www.eia.gov/electricity/data/eia860m/xls/{m}_generator{y}.xlsx"
@@ -48,9 +48,21 @@ async def test_eia860m(mocker):
         "pudl_archiver.archivers.eia860m.Eia860MArchiver.get_hyperlinks",
         get_hyperlinks,
     )
+
+    def make_fake_file(_url, file, **_kwargs):
+        with (tmp_path / file).open("w") as f:
+            f.write(f"fake data for {file}")
+
+    mocker.patch(
+        "pudl_archiver.archivers.eia860m.Eia860MArchiver.download_file",
+        mocker.AsyncMock(side_effect=make_fake_file),
+    )
     archiver = Eia860MArchiver(mock_session, only_years=[2019, 2022])
     resources = [res async for res in archiver.get_resources()]
     assert len(resources) == 2
+    for resource in resources:
+        info = await resource
+        assert len(info.partitions["year_month"]) == 12
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Overview

Closes #239 - we can get around the 100-file limit on Zenodo by zipping things into fewer files.

Currently stacked on top of `multi-zip-cems` but could easily just get rebased on top of `main` once `stop-discarding-drafts` gets merged.  Though the `add_to_archive` method would maybe cause a conflict... but it should be all pretty straightforward.

We'll have to handle the new partition format downstream - I think @cmgosnell had volunteered for this?


# Testing

I ran `pudl_archiver --datasets eia860m  --sandbox --only-years 2020 2021` and got [this output](https://sandbox.zenodo.org/records/13857). Good signs:

- partitions in `datapackage.json` look good and include all the `202X-XX` months we expect
- zip files are ~90 MB each and include 12 8MB files each - makes sense, xlsx files are already compressed
- one file per year



