### PR TITLE
Make message more compact & limit it to 3000 characters

### DIFF
--- a/scripts/make_slack_notification_message.py
+++ b/scripts/make_slack_notification_message.py
@@ -17,6 +17,7 @@ hide large messages (such as a file diff) behind a "See more" action.
 import argparse
 import itertools
 import json
+from collections import defaultdict
 from pathlib import Path
 
 
@@ -39,16 +40,19 @@ def main(summary_files: list[Path]) -> None:
         name = summary["dataset_name"]
         url = summary["record_url"]
         if file_changes := summary["file_changes"]:
-            changes = f"```\n{json.dumps(file_changes, indent=2)}\n```"
+            abridged_changes = defaultdict(list)
+            for change in file_changes:
+                abridged_changes[change["diff_type"]].append(change["name"])
+            changes = f"```\n{json.dumps(abridged_changes, indent=2)}\n```"
         else:
             changes = "No changes."
+
+        max_len = 3000
+        text = f"<{url}|*{name}*>\n{changes}"[:max_len]
         return [
             {
                 "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"<{url}|*{name}*>\n{changes}",
-                },
+                "text": {"type": "mrkdwn", "text": text},
             },
         ]
 


### PR DESCRIPTION
Archive-notify failed due to the 3001 character limit:

https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/7265550885/job/19795893314

I made the output a bit less verbose, truncated the output, and added the fallback `"text"` field mentioned in the error message above.

Tested by running 

```
pudl_archiver --datasets eia860m  --sandbox --only-years 2018 2020 --summary-file eia860m.json
```

And then 

```
./scripts/make_slack_notification_message.py --summary-files *-summary.json | pbcopy
```

And then pasting that output into https://app.slack.com/block-kit-builder/ (removing the top-level `text` field) to verify that it looked fine.
