### PR TITLE
Update artifact uploads due to breaking changes in v4

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -57,7 +57,7 @@ jobs:
         id: upload_summaries
         uses: actions/upload-artifact@v4
         with:
-          name: run-summaries
+          name: run-summaries-${{ matrix.dataset }}
           path: ${{ matrix.dataset }}_run_summary.json
 
   archive-notify:
@@ -70,7 +70,8 @@ jobs:
         id: download
         uses: actions/download-artifact@v4
         with:
-          name: run-summaries
+          pattern: run-summaries-*
+          merge-multiple: true
       - name: show summaries
         run: ls -R
       - name: Munge summaries together


### PR DESCRIPTION
They made artifacts immutable in the upload/download-artifacts@v4 versions.

Just naively applying the [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact) here.