### PR TITLE
Force zipfiles to be identical by fixing timestamps of zipped files

### DIFF
--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from pudl_archiver.archivers import validate
 from pudl_archiver.frictionless import DataPackage, ResourceInfo
-from pudl_archiver.utils import retry_async
+from pudl_archiver.utils import add_to_archive_stable_hash, retry_async
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
 
@@ -193,12 +193,9 @@ class AbstractDatasetArchiver(ABC):
             "w",
             compression=zipfile.ZIP_DEFLATED,
         ) as archive:
-            info = zipfile.ZipInfo(
-                filename=filename,
-                # Set fixed date to enable hash comparisons between archives
-                date_time=(1980, 1, 1, 0, 0, 0),
+            add_to_archive_stable_hash(
+                archive=archive, filename=filename, data=response_bytes
             )
-            archive.writestr(info, response_bytes)
 
     def add_to_archive(self, target_archive: Path, name: str, blob: typing.BinaryIO):
         """Add a file to a ZIP archive.
@@ -213,12 +210,7 @@ class AbstractDatasetArchiver(ABC):
             "a",
             compression=zipfile.ZIP_DEFLATED,
         ) as archive:
-            info = zipfile.ZipInfo(
-                filename=name,
-                # Set fixed date to enable hash comparisons between archives
-                date_time=(1980, 1, 1, 0, 0, 0),
-            )
-            archive.writestr(info, blob.read())
+            add_to_archive_stable_hash(archive=archive, filename=name, data=blob.read())
 
     async def get_hyperlinks(
         self,

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -193,7 +193,12 @@ class AbstractDatasetArchiver(ABC):
             "w",
             compression=zipfile.ZIP_DEFLATED,
         ) as archive:
-            archive.writestr(filename, response_bytes)
+            info = zipfile.ZipInfo(
+                filename=filename,
+                # Set fixed date to enable hash comparisons between archives
+                date_time=(1980, 1, 1, 0, 0, 0),
+            )
+            archive.writestr(info, response_bytes)
 
     def add_to_archive(self, target_archive: Path, name: str, blob: typing.BinaryIO):
         """Add a file to a ZIP archive.
@@ -208,7 +213,12 @@ class AbstractDatasetArchiver(ABC):
             "a",
             compression=zipfile.ZIP_DEFLATED,
         ) as archive:
-            archive.writestr(name, blob.read())
+            info = zipfile.ZipInfo(
+                filename=name,
+                # Set fixed date to enable hash comparisons between archives
+                date_time=(1980, 1, 1, 0, 0, 0),
+            )
+            archive.writestr(info, blob.read())
 
     async def get_hyperlinks(
         self,

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,7 +1,10 @@
+import hashlib
+import time
+import zipfile
 from asyncio import to_thread
 
 import pytest
-from pudl_archiver.utils import retry_async
+from pudl_archiver.utils import add_to_archive_stable_hash, retry_async
 
 
 @pytest.mark.asyncio
@@ -27,3 +30,29 @@ async def test_retry_async(mocker):
 
     assert action_mock.call_count == 1
     assert sleep_mock.call_count == 0
+
+
+def test_stable_zip_hash(tmp_path):
+    a_archive = tmp_path / "a.zip"
+    b_archive = tmp_path / "b.zip"
+
+    file_contents = "Call me Ishmael."
+
+    def write_get_digest(archive, filename, data):
+        with zipfile.ZipFile(archive, "w") as f:
+            add_to_archive_stable_hash(f, filename=filename, data=data)
+        with archive.open("rb") as f:
+            digest = hashlib.file_digest(f, "md5")
+        return digest.hexdigest()
+
+    a_digest = write_get_digest(a_archive, "file1", file_contents)
+
+    # ZipInfo has time resolution of 1s; we could patch out "datetime.now()",
+    # but we don't know if that is what ZipFile.writestr() uses under the hood
+    # to set the default timestamp. So unfortunately we must sleep for a whole
+    # second here.
+    time.sleep(1)
+
+    b_digest = write_get_digest(b_archive, "file1", file_contents)
+
+    assert a_digest == b_digest


### PR DESCRIPTION
The MD5 checksums of zipfiles we make (CEMS, 860M) change even when the files zipped in them stay the same. This is because the file modification time changes. This PR manually fixes the `datetime` of files when we add them to a zipfile repository. 

To test:
`pudl_archiver --datasets eia860m --sandbox --initialize --summary-file test.json --only-years 2015`
Run twice and compare checksums on the zipped file for each repository.