### PR TITLE
Change PHMSA partitions to use `year` instead of `years`

### DIFF
--- a/src/pudl_archiver/archivers/phmsagas.py
+++ b/src/pudl_archiver/archivers/phmsagas.py
@@ -89,7 +89,7 @@ class PhmsaGasArchiver(AbstractDatasetArchiver):
         return ResourceInfo(
             local_path=download_path,
             partitions={
-                "years": years,
+                "year": years,
                 "form": form,
             },
         )


### PR DESCRIPTION
To make the excel extractor in `pudl` work consistently with the PHMSA data, update the `years` partition to `year` to match all other partitions. See draft dataset at: https://zenodo.org/deposit/10493790