### PR TITLE
Add `eia_bulk_elec` to monthly automated archiver runs

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -4,7 +4,7 @@ name: run-archiver
 on:
   workflow_dispatch:
   schedule:
-    - cron: "21 4 1 * *" # 4:21 AM UTC, first of every month
+    - cron: "21 8 1 * *" # 8:21 AM UTC, first of every month
 
 jobs:
   archive-run:
@@ -18,6 +18,7 @@ jobs:
           - eia860m
           - eia923
           - epacems
+          - eia_bulk_elec
 
       fail-fast: false
     runs-on: ubuntu-latest

--- a/environment.yml
+++ b/environment.yml
@@ -8,9 +8,5 @@ dependencies:
   - pip>=21,<24
   - python>=3.11,<3.12
   - setuptools>=66
-  # fiona is a transitive dependency which needs GDAL. so we install with conda
-  # TODO: we shouldn't have to install all this geo stuff, so once we break the
-  # dependency on `pudl` we should remove this too.
-  - fiona>=1.9.5
   - pip:
       - --editable ./[dev,docs,tests]

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,9 @@ dependencies:
   - pip>=21,<24
   - python>=3.11,<3.12
   - setuptools>=66
+  # fiona is a transitive dependency which needs GDAL. so we install with conda
+  # TODO: we shouldn't have to install all this geo stuff, so once we break the
+  # dependency on `pudl` we should remove this too.
+  - fiona>=1.9.5
   - pip:
       - --editable ./[dev,docs,tests]

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,6 @@ dependencies:
   # fiona is a transitive dependency which needs GDAL. so we install with conda
   # TODO: we shouldn't have to install all this geo stuff, so once we break the
   # dependency on `pudl` we should remove this too.
-  - fiona>=1.8
+  - fiona>=1.9.5
   - pip:
       - --editable ./[dev,docs,tests]


### PR DESCRIPTION
The issue found in #256 has been fixed through the creation of a new archive (v 3.0). This PR simply adds the `eia_bulk_elec` dataset to the monthly scheduled archiver run, as this dataset is relatively regularly updated. It also bumps `fiona` to `>=1.9.5` to match the version in PUDL and fix a CI issue.