### PR TITLE
Update zipfile type check validation and add file checks into summary JSON files

### DIFF
--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -268,8 +268,14 @@ def _validate_file_type(path: Path, buffer: BytesIO) -> bool:
     """Check that file appears valid based on extension."""
     extension = path.suffix
 
-    if extension == ".zip" or extension == ".xlsx":
+    if extension == ".xlsx":
         return zipfile.is_zipfile(buffer)
+
+    if extension == ".zip":
+        if zipfile.is_zipfile(buffer):
+            zip_test = zipfile.ZipFile(buffer).testzip()
+            return zip_test is None  # None if no error
+        return False
 
     if extension == ".xml" or extension == ".xbrl" or extension == ".xsd":
         return _validate_xml(buffer)

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -37,7 +37,6 @@ class FileUniversalValidation(ValidationTestResult):
     """ValidationTestResult applied to a single file for all data sources."""
 
     resource_name: Path
-    always_serialize_in_summary: bool = False
 
 
 def validate_filetype(
@@ -46,7 +45,7 @@ def validate_filetype(
     """Check that file is valid based on type."""
     return FileUniversalValidation(
         name="Valid Filetype Test",
-        description="Check that file appears to be valid based on it's extension.",
+        description="Check that all files appear to be valid based on their extensions.",
         required_for_run_success=required_for_run_success,
         resource_name=path,
         success=_validate_file_type(path, BytesIO(path.read_bytes())),
@@ -59,7 +58,7 @@ def validate_file_not_empty(
     """Check that file is valid based on type."""
     return FileUniversalValidation(
         name="Empty File Test",
-        description="Check that file is not empty.",
+        description="Check that files are not empty.",
         required_for_run_success=required_for_run_success,
         resource_name=path,
         success=path.stat().st_size > 0,
@@ -77,7 +76,7 @@ def validate_zip_layout(
 
     return FileUniversalValidation(
         name="Zipfile Layout Test",
-        description="Check that the internal layout of a zipfile is as expected.",
+        description="Check that the internal layout of zipfiles are as expected.",
         required_for_run_success=required_for_run_success,
         resource_name=path,
         success=valid_layout,

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from aiohttp import ClientSession
 from pudl_archiver.archivers.classes import AbstractDatasetArchiver, ArchiveAwaitable
-from pudl_archiver.archivers.validate import ValidationTestResult
+from pudl_archiver.archivers.validate import ValidationTestResult, validate_filetype
 from pudl_archiver.frictionless import Resource, ResourceInfo
 
 
@@ -694,3 +694,16 @@ def test_check_data_continuity(datapackage, new_resources, success, notes):
     validation = archiver._check_data_continuity(new_datapackage)
     assert validation.success == success
     assert notes in validation.notes[0]  # Check exact success/fail reason
+
+
+def test_check_file_type(
+    mocker,
+    good_zipfile,
+    bad_zipfile,
+):
+    """Test the ``_check_file_size`` validation test."""
+    validation_result = validate_filetype(good_zipfile, True)
+    assert validation_result.success
+
+    validation_result = validate_filetype(bad_zipfile, True)
+    assert not validation_result.success


### PR DESCRIPTION
This PR addresses #245:

- adds `test_zip()` into the zipfile file check method.
- updates the validation summary to include file checks by default
- adds a test to ensure bad zipfiles fail our file check