### PR TITLE
Revert "Update frictionless requirement from <5,>=4.40 to >=4.40,<6"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
     "coloredlogs>=14",
     "feedparser>=6.0",
-    "frictionless>=4.40,<6",
+    "frictionless>=4.40,<5",
     "pydantic>=2.0,<3",
     "python-dotenv~=1.0.0",
     "semantic_version>=2.8,<3",


### PR DESCRIPTION
Reverts catalyst-cooperative/pudl-archiver#266. See discussion in that PR, we've forcibly pinned the `pudl` repo to be <5 for now.