### PR TITLE
Fix GHA runs for EIA 176

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         dataset:
+          - eia176
           - eia191
           - eia757a
           - eia860

--- a/scripts/make_slack_notification_message.py
+++ b/scripts/make_slack_notification_message.py
@@ -41,7 +41,7 @@ def main(summary_files: list[Path]) -> None:
         url = summary["record_url"]
         if file_changes := summary["file_changes"]:
             abridged_changes = defaultdict(list)
-            for change in sorted(file_changes, key=lambda x: file_changes[x]["name"]):
+            for change in file_changes:
                 abridged_changes[change["diff_type"]].append(change["name"])
             changes = f"```\n{json.dumps(abridged_changes, indent=2)}\n```"
         else:

--- a/scripts/make_slack_notification_message.py
+++ b/scripts/make_slack_notification_message.py
@@ -41,7 +41,7 @@ def main(summary_files: list[Path]) -> None:
         url = summary["record_url"]
         if file_changes := summary["file_changes"]:
             abridged_changes = defaultdict(list)
-            for change in sorted(file_changes):
+            for change in sorted(file_changes, key=lambda x: file_changes[x]["name"]):
                 abridged_changes[change["diff_type"]].append(change["name"])
             changes = f"```\n{json.dumps(abridged_changes, indent=2)}\n```"
         else:

--- a/scripts/make_slack_notification_message.py
+++ b/scripts/make_slack_notification_message.py
@@ -41,7 +41,7 @@ def main(summary_files: list[Path]) -> None:
         url = summary["record_url"]
         if file_changes := summary["file_changes"]:
             abridged_changes = defaultdict(list)
-            for change in file_changes:
+            for change in sorted(file_changes):
                 abridged_changes[change["diff_type"]].append(change["name"])
             changes = f"```\n{json.dumps(abridged_changes, indent=2)}\n```"
         else:

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -66,14 +66,14 @@ async def archive_datasets(
         publish_key = os.environ["ZENODO_TOKEN_PUBLISH"]
 
     async def on_request_start(session, trace_config_ctx, params):
-        logger.info(f"Starting request {params.url}: headers {params.headers}")
+        logger.debug(f"Starting request {params.url}: headers {params.headers}")
 
     async def on_response_chunk_received(session, trace_config_ctx, params):
-        logger.info(f"Chunk received from {params.url}")
+        logger.debug(f"Chunk received from {params.url}")
 
     async def on_request_end(session, trace_config_ctx, params):
-        logger.info(f"Ending request {params.url}: response {params.response.status}")
-        logger.info("Sent headers: %s" % params.response.request_info.headers)
+        logger.debug(f"Ending request {params.url}: response {params.response.status}")
+        logger.debug("Sent headers: %s" % params.response.request_info.headers)
 
     trace_config = aiohttp.TraceConfig()
     trace_config.on_request_start.append(on_request_start)

--- a/src/pudl_archiver/__init__.py
+++ b/src/pudl_archiver/__init__.py
@@ -66,13 +66,14 @@ async def archive_datasets(
         publish_key = os.environ["ZENODO_TOKEN_PUBLISH"]
 
     async def on_request_start(session, trace_config_ctx, params):
-        logger.debug(f"Starting request {params.url}: headers {params.headers}")
+        logger.info(f"Starting request {params.url}: headers {params.headers}")
 
     async def on_response_chunk_received(session, trace_config_ctx, params):
-        logger.debug(f"Chunk received from {params.url}")
+        logger.info(f"Chunk received from {params.url}")
 
     async def on_request_end(session, trace_config_ctx, params):
-        logger.debug(f"Ending request {params.url}: response {params.response.status}")
+        logger.info(f"Ending request {params.url}: response {params.response.status}")
+        logger.info("Sent headers: %s" % params.response.request_info.headers)
 
     trace_config = aiohttp.TraceConfig()
     trace_config.on_request_start.append(on_request_start)

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -223,6 +223,7 @@ class AbstractDatasetArchiver(ABC):
     async def get_json(self, url: str, **kwargs) -> dict[str, str]:
         """Get a JSON and return it as a dictionary."""
         response = await retry_async(self.session.get, args=[url], kwargs=kwargs)
+        logger.warn(f"Status: {response.status_code}")
         response_bytes = await retry_async(response.read)
         try:
             json_obj = json.loads(response_bytes.decode("utf-8"))

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -223,7 +223,6 @@ class AbstractDatasetArchiver(ABC):
     async def get_json(self, url: str, **kwargs) -> dict[str, str]:
         """Get a JSON and return it as a dictionary."""
         response = await retry_async(self.session.get, args=[url], kwargs=kwargs)
-        logger.warn(f"Status: {response.status_code}")
         response_bytes = await retry_async(response.read)
         try:
             json_obj = json.loads(response_bytes.decode("utf-8"))

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -227,7 +227,7 @@ class AbstractDatasetArchiver(ABC):
         try:
             json_obj = json.loads(response_bytes.decode("utf-8"))
         except json.JSONDecodeError:
-            logger.warn(f"Invalid JSON string: {response_bytes}")
+            raise AssertionError(f"Invalid JSON string: {response_bytes}")
         return json_obj
 
     async def get_hyperlinks(

--- a/src/pudl_archiver/archivers/eia/eia176.py
+++ b/src/pudl_archiver/archivers/eia/eia176.py
@@ -21,6 +21,9 @@ class Eia176Archiver(AbstractDatasetArchiver):
     name = "eia176"
     base_url = "https://www.eia.gov/naturalgas/ngqs/data/report/RPC/data/"
     items_url = "https://www.eia.gov/naturalgas/ngqs/data/items"
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) Gecko/20100101 Firefox/77.0"
+    }
 
     async def get_items(self, url: str = items_url) -> list[str]:
         """Get list of item codes from EIA NQGS portal."""
@@ -60,7 +63,7 @@ class Eia176Archiver(AbstractDatasetArchiver):
                 download_url += f"{item}/"
             download_url = download_url[:-1]  # Drop trailing slash
 
-            json_response = await self.get_json(download_url)
+            json_response = await self.get_json(download_url, headers=self.headers)
             # Get data into dataframes
             try:
                 dataframes.append(

--- a/src/pudl_archiver/archivers/eia/eia176.py
+++ b/src/pudl_archiver/archivers/eia/eia176.py
@@ -1,5 +1,7 @@
 """Download EIA 176 data."""
+import asyncio
 import logging
+import random
 import zipfile
 
 import pandas as pd
@@ -14,6 +16,12 @@ from pudl_archiver.utils import add_to_archive_stable_hash
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
 
+USER_AGENTS = [
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) Gecko/20100101 Firefox/77.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:107.0) Gecko/20100101 Firefox/107.0",
+    "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Mobile Safari/537.36",
+]
+
 
 class Eia176Archiver(AbstractDatasetArchiver):
     """EIA 176 archiver."""
@@ -21,9 +29,6 @@ class Eia176Archiver(AbstractDatasetArchiver):
     name = "eia176"
     base_url = "https://www.eia.gov/naturalgas/ngqs/data/report/RPC/data/"
     items_url = "https://www.eia.gov/naturalgas/ngqs/data/items"
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:77.0) Gecko/20100101 Firefox/77.0"
-    }
 
     async def get_items(self, url: str = items_url) -> list[str]:
         """Get list of item codes from EIA NQGS portal."""
@@ -55,6 +60,7 @@ class Eia176Archiver(AbstractDatasetArchiver):
         dataframes = []
 
         for i in range(0, len(items_list), 20):
+            rand = random.randint(0, 2)  # noqa: S311
             logger.debug(f"Getting items {i}-{i+20} of data for {year}")
             # Chunk items list into 20 to avoid error message
             download_url = self.base_url + f"{year}/{year}/ICA/Name/"
@@ -63,7 +69,9 @@ class Eia176Archiver(AbstractDatasetArchiver):
                 download_url += f"{item}/"
             download_url = download_url[:-1]  # Drop trailing slash
 
-            json_response = await self.get_json(download_url, headers=self.headers)
+            json_response = await self.get_json(
+                download_url, headers={"User-Agent": USER_AGENTS[rand]}
+            )  # Generate a random user agent
             # Get data into dataframes
             try:
                 dataframes.append(
@@ -73,6 +81,7 @@ class Eia176Archiver(AbstractDatasetArchiver):
                 raise AssertionError(
                     f"{ex}: Error processing dataframe for {year} - see {download_url}."
                 )
+            await asyncio.sleep(5)  # Add sleep to prevent user-agent blocks
 
         logger.info(f"Compiling data for {year}")
         dataframe = pd.concat(dataframes)


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #279.

What problem does this address?
Fixes the current blocking of the EIA 176 archiver (only) from downloading all fields of 176 data.

What did you change in this PR?
Added rotating `user-agent`s to EIA 176 archiver, improved error handling of `get_json`. Added a log to enable header tracing from `aiohttp` calls.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `run-archiver` GHA and verify that 176 archiver runs successfully.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
