### PR TITLE
Add `eiawater` to automatic archiver

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -21,6 +21,7 @@ jobs:
           - eia861
           - eia860m
           - eia923
+          - eiawater
           - eia_bulk_elec
           - epacamd_eia
           - mshamines


### PR DESCRIPTION
# Overview
Addresses part of #285.

What problem does this address?
Zenodo fixed the backend issue that was preventing us from making new `eiawater` archives (see #276 and #285). Now, let's add it to the archiver.

What did you change in this PR?
Manually made a new `eiawater` archive with `--refresh-metadata` to fix keyword issues, and added it to the GHA action.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run the GHA action.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
