### PR TITLE
Archive NREL ATB for Electricity

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -26,6 +26,7 @@ jobs:
           - eia_bulk_elec
           - epacamd_eia
           - mshamines
+          - nrelatb
           - phmsagas
 
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This command will download the latest available data and create archives for eac
 requested datasource requested. The supported datasources include `censusdp1tract`,
 `eia_bulk_elec`, `eia176`, `eia191`, `eia757a`,`eia860`, `eia860m`, `eia861`, `eia923`,
 `eiaaeo`, `eiawater`, `epacems`, `epacamd_eia`, `ferc1`, `ferc2`, `ferc6`, `ferc60`,
-`ferc714`, `phmsagas`, `mshamines`.
+`ferc714`, `nrelatb`, `phmsagas`, `mshamines`.
 
 There are also four optional flags available:
 

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -56,7 +56,7 @@ mshamines:
   production_doi: 10.5281/zenodo.7683517
   sandbox_doi: 10.5072/zenodo.3242
 nrelatb:
-  sandbox_doi: 10.5072/zenodo.37904
+  sandbox_doi: 10.5072/zenodo.38192
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
   sandbox_doi: 10.5072/zenodo.3357

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -56,6 +56,7 @@ mshamines:
   production_doi: 10.5281/zenodo.7683517
   sandbox_doi: 10.5072/zenodo.3242
 nrelatb:
+  production_doi: 10.5281/zenodo.10839267
   sandbox_doi: 10.5072/zenodo.38192
 phmsagas:
   production_doi: 10.5281/zenodo.7683351

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -54,6 +54,8 @@ ferc714:
 mshamines:
   production_doi: 10.5281/zenodo.7683517
   sandbox_doi: 10.5072/zenodo.3242
+nrelatb:
+  sandbox_doi: 10.5072/zenodo.37904
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
   sandbox_doi: 10.5072/zenodo.3357

--- a/src/pudl_archiver/archivers/eia/nrelatb.py
+++ b/src/pudl_archiver/archivers/eia/nrelatb.py
@@ -1,0 +1,33 @@
+"""Download NREL ATB for Electricity Parquet data."""
+
+from pathlib import Path
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+# Note: Using non s3:// link here as compatibility between asyncio and botocore is
+# complex.
+BASE_URL = "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/"
+
+
+class NrelAtbArchiver(AbstractDatasetArchiver):
+    """NREL ATB for Electricity archiver."""
+
+    name = "nrelatb"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download NREL ATB resources."""
+        for year in range(2019, 2024):
+            if self.valid_year(year):
+                yield self.get_year_resource(year)
+
+    async def get_year_resource(self, year: int) -> tuple[Path, dict]:
+        """Download parquet file."""
+        url = f"{BASE_URL}/{year}/ATBe.parquet"
+        download_path = self.download_directory / f"nrelatb-{year}.parquet"
+        await self.download_file(url, download_path)
+
+        return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/eia/nrelatb.py
+++ b/src/pudl_archiver/archivers/eia/nrelatb.py
@@ -10,7 +10,7 @@ from pudl_archiver.archivers.classes import (
 
 # Note: Using non s3:// link here as compatibility between asyncio and botocore is
 # complex.
-BASE_URL = "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet/"
+BASE_URL = "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet"
 
 
 class NrelAtbArchiver(AbstractDatasetArchiver):

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Literal
 
+import pyarrow as pa
 from pydantic import BaseModel
 
 from pudl_archiver.frictionless import DataPackage, Resource, ZipLayout
@@ -280,6 +281,13 @@ def _validate_file_type(path: Path, buffer: BytesIO) -> bool:
 
     if extension == ".xml" or extension == ".xbrl" or extension == ".xsd":
         return _validate_xml(buffer)
+
+    if extension == ".parquet":
+        try:
+            pa.parquet.ParquetFile(buffer)
+            return True
+        except (pa.lib.ArrowInvalid, pa.lib.ArrowException):
+            return False
 
     logger.warning(f"No validations defined for files of type: {extension} - {path}")
     return True

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -283,11 +283,7 @@ def _validate_file_type(path: Path, buffer: BytesIO) -> bool:
         return _validate_xml(buffer)
 
     if extension == ".parquet":
-        try:
-            pa.parquet.ParquetFile(buffer)
-            return True
-        except (pa.lib.ArrowInvalid, pa.lib.ArrowException):
-            return False
+        return _validate_parquet(buffer)
 
     logger.warning(f"No validations defined for files of type: {extension} - {path}")
     return True
@@ -300,3 +296,11 @@ def _validate_xml(buffer: BytesIO) -> bool:
         return False
 
     return True
+
+
+def _validate_parquet(buffer: BytesIO) -> bool:
+    try:
+        pa.parquet.ParquetFile(buffer)
+        return True
+    except (pa.lib.ArrowInvalid, pa.lib.ArrowException):
+        return False

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -28,7 +28,7 @@ def parse_main():
         help="Years to download data for. Supported datasets: censusdp1tract, eia176, "
         "eia191, eia757a, eia860, eia860m, eia861, eia923, eia_bulk_elec, eiaaeo, "
         "eiawater, epacamd_eia, epacems, ferc1, ferc2, ferc6, ferc60, ferc714, "
-        "mshamines, phmsagas",
+        "mshamines, nrelatb, phmsagas",
         type=int,
     )
     parser.add_argument(

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -19,6 +19,7 @@ MEDIA_TYPES: dict[str, str] = {
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "csv": "text/csv",
     "txt": "text/csv",
+    "parquet": "application/vnd.apache.parquet",
 }
 
 


### PR DESCRIPTION
# Overview

Closes #294.

What problem does this address?
Archives NREL ATB.

What did you change in this PR?
Point directly to download link for NREL ATB data, and add archiver. We aren't using the `s3://` link to avoid having to import `boto3` and deal with `boto3` and `asyncio` incompatibilities. Also adds a validation method for Parquet filetypes.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Inspect the sandbox archive: https://sandbox.zenodo.org/records/37905

# To-do list

```[tasklist]
- [x] Add validation method for parquet filetypes
- [x] Once approved, make production archive and add production DOI to dataset_doi.yaml
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
