### PR TITLE
Archive EIA 930 data

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -21,6 +21,7 @@ jobs:
           - eia861
           - eia860m
           - eia923
+          - eia930
           - eiaaeo
           - eiawater
           - eia_bulk_elec

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ pudl_archiver --datasets {list_of_datasources}
 This command will download the latest available data and create archives for each
 requested datasource requested. The supported datasources include `censusdp1tract`,
 `eia_bulk_elec`, `eia176`, `eia191`, `eia757a`,`eia860`, `eia860m`, `eia861`, `eia923`,
-`eiaaeo`, `eiawater`, `epacems`, `epacamd_eia`, `ferc1`, `ferc2`, `ferc6`, `ferc60`,
-`ferc714`, `nrelatb`, `phmsagas`, `mshamines`.
+`eia930`, `eiaaeo`, `eiawater`, `epacems`, `epacamd_eia`, `ferc1`, `ferc2`, `ferc6`,
+`ferc60`, `ferc714`, `nrelatb`, `phmsagas`, `mshamines`.
 
 There are also four optional flags available:
 

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -22,6 +22,8 @@ eia861:
 eia923:
   production_doi: 10.5281/zenodo.4127039
   sandbox_doi: 10.5072/zenodo.3166
+eia930:
+  sandbox_doi: 10.5072/zenodo.38234
 eiaaeo:
   production_doi: 10.5281/zenodo.10838487
   sandbox_doi: 10.5072/zenodo.37746

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -23,6 +23,7 @@ eia923:
   production_doi: 10.5281/zenodo.4127039
   sandbox_doi: 10.5072/zenodo.3166
 eia930:
+  production_doi: 10.5281/zenodo.10839904
   sandbox_doi: 10.5072/zenodo.38234
 eiaaeo:
   production_doi: 10.5281/zenodo.10838487

--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -23,8 +23,8 @@ eia923:
   production_doi: 10.5281/zenodo.4127039
   sandbox_doi: 10.5072/zenodo.3166
 eia930:
-  production_doi: 10.5281/zenodo.10839904
-  sandbox_doi: 10.5072/zenodo.38234
+  production_doi: 10.5281/zenodo.10840077
+  sandbox_doi: 10.5072/zenodo.38409
 eiaaeo:
   production_doi: 10.5281/zenodo.10838487
   sandbox_doi: 10.5072/zenodo.37746

--- a/src/pudl_archiver/archivers/eia/eia930.py
+++ b/src/pudl_archiver/archivers/eia/eia930.py
@@ -1,0 +1,75 @@
+"""Download EIA-930 data."""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+from pudl_archiver.frictionless import ZipLayout
+
+BASE_URL = "https://www.eia.gov/electricity/gridmonitor/sixMonthFiles/"
+FILE_LIST_URL = "https://www.eia.gov/electricity/gridmonitor/sixMonthFiles/EIA930_File_List_Meta.csv"
+
+logger = logging.getLogger(f"catalystcoop.{__name__}")
+
+
+class Eia930Archiver(AbstractDatasetArchiver):
+    """EIA 930 archiver."""
+
+    name = "eia930"
+
+    async def get_file_list(self) -> pd.DataFrame:
+        """Get EIA 930 file list dataframe."""
+        return pd.read_csv(FILE_LIST_URL)
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download EIA-930 resources."""
+        file_list = await self.get_file_list()
+        year_period = (
+            file_list[["YEAR", "PERIOD"]]
+            .value_counts()
+            .reset_index()
+            .drop(columns=["count"])
+            .sort_values("YEAR")
+        )
+        for index, period in year_period.iterrows():
+            if self.valid_year(period.YEAR):
+                yield self.get_year_resource(
+                    file_list=file_list, year=period.YEAR, half_year=period.PERIOD
+                )
+
+    async def get_year_resource(
+        self, file_list: pd.DataFrame, year=int, half_year=int
+    ) -> tuple[Path, dict]:
+        """Download zip file of all files in year."""
+        logger.debug(f"Downloading data for {year}h{half_year}.")
+        archive_path = self.download_directory / f"eia930-{year}h{half_year}.zip"
+        data_paths_in_archive = set()
+        period_files = file_list[
+            (year == file_list.YEAR) & (half_year == file_list.PERIOD)
+        ]
+        for index, file in period_files.iterrows():
+            url = BASE_URL + file.FILENAME
+            download_name = f"eia930-{year}h{half_year}-{file.DESCRIPTION.lower()}.csv"
+            download_path = self.download_directory / download_name
+            await self.download_file(url, download_path)
+            self.add_to_archive(
+                target_archive=archive_path,
+                name=download_name,
+                blob=download_path.open("rb"),
+            )
+            data_paths_in_archive.add(download_name)
+            # Don't want to leave multiple giant CSVs on disk, so delete
+            # immediately after they're safely stored in the ZIP
+            download_path.unlink()
+
+        return ResourceInfo(
+            local_path=archive_path,
+            partitions={"half_year": f"{year}h{half_year}"},
+            layout=ZipLayout(file_paths=data_paths_in_archive),
+        )

--- a/src/pudl_archiver/archivers/eia/eia930.py
+++ b/src/pudl_archiver/archivers/eia/eia930.py
@@ -47,15 +47,17 @@ class Eia930Archiver(AbstractDatasetArchiver):
         self, file_list: pd.DataFrame, year=int, half_year=int
     ) -> tuple[Path, dict]:
         """Download zip file of all files in year."""
-        logger.debug(f"Downloading data for {year}h{half_year}.")
-        archive_path = self.download_directory / f"eia930-{year}h{half_year}.zip"
+        logger.debug(f"Downloading data for {year}half{half_year}.")
+        archive_path = self.download_directory / f"eia930-{year}half{half_year}.zip"
         data_paths_in_archive = set()
         period_files = file_list[
             (year == file_list.YEAR) & (half_year == file_list.PERIOD)
         ]
         for index, file in period_files.iterrows():
             url = BASE_URL + file.FILENAME
-            download_name = f"eia930-{year}h{half_year}-{file.DESCRIPTION.lower()}.csv"
+            download_name = (
+                f"eia930-{year}half{half_year}-{file.DESCRIPTION.lower()}.csv"
+            )
             download_path = self.download_directory / download_name
             await self.download_file(url, download_path)
             self.add_to_archive(
@@ -70,6 +72,6 @@ class Eia930Archiver(AbstractDatasetArchiver):
 
         return ResourceInfo(
             local_path=archive_path,
-            partitions={"half_year": f"{year}h{half_year}"},
+            partitions={"half_year": f"{year}half{half_year}"},
             layout=ZipLayout(file_paths=data_paths_in_archive),
         )

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -26,8 +26,8 @@ def parse_main():
         "--only-years",
         nargs="*",
         help="Years to download data for. Supported datasets: censusdp1tract, eia176, "
-        "eia191, eia757a, eia860, eia860m, eia861, eia923, eia_bulk_elec, eiaaeo, "
-        "eiawater, epacamd_eia, epacems, ferc1, ferc2, ferc6, ferc60, ferc714, "
+        "eia191, eia757a, eia860, eia860m, eia861, eia923, eia930, eia_bulk_elec, "
+        "eiaaeo, eiawater, epacamd_eia, epacems, ferc1, ferc2, ferc6, ferc60, ferc714, "
         "mshamines, nrelatb, phmsagas",
         type=int,
     )

--- a/tests/unit/archive_validate_test.py
+++ b/tests/unit/archive_validate_test.py
@@ -311,12 +311,12 @@ def test_run_summary_success(specs, expected_success):
     [
         (
             BytesIO(
-                b"PK\00\00\00\00\00!\00\\A1\\B7\\FCFr\00\00R\00\00\00[Content_Types].xml"
+                b'"PK\00\00\00\00\00!\00\\A1\\B7\\FCFr\00\00R\00\00\00[Content_Types].xml'
             ),
             False,
         ),
         (
-            BytesIO(b"'name','address','telephone'/njohn,123 street,1234567890"),
+            BytesIO(b"'name','address','telephone'\njohn,123 street,1234567890"),
             True,
         ),
         (
@@ -324,7 +324,7 @@ def test_run_summary_success(specs, expected_success):
             False,
         ),
     ],
-    ids=["Excel header", "CSV file", "Text file"],
+    ids=["Parser error", "CSV file", "Text file"],
 )
 def test_validate_csv(file_bytes, expected_success):
     success = validate._validate_csv(file_bytes)

--- a/tests/unit/archive_validate_test.py
+++ b/tests/unit/archive_validate_test.py
@@ -3,6 +3,7 @@
 import itertools
 import logging
 import zipfile
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -303,3 +304,28 @@ def test_run_summary_success(specs, expected_success):
         record_url=Url("https://www.catalyst.coop/bogus-record-url"),
     )
     assert summary.success == expected_success
+
+
+@pytest.mark.parametrize(
+    "file_bytes,expected_success",
+    [
+        (
+            BytesIO(
+                b"PK\00\00\00\00\00!\00\\A1\\B7\\FCFr\00\00R\00\00\00[Content_Types].xml"
+            ),
+            False,
+        ),
+        (
+            BytesIO(b"'name','address','telephone'/njohn,123 street,1234567890"),
+            True,
+        ),
+        (
+            BytesIO(b"hello world"),
+            False,
+        ),
+    ],
+    ids=["Excel header", "CSV file", "Text file"],
+)
+def test_validate_csv(file_bytes, expected_success):
+    success = validate._validate_csv(file_bytes)
+    assert success == expected_success


### PR DESCRIPTION
# Overview

Closes #295 

What problem does this address?
Archives raw EIA 930 data.

What did you change in this PR?
- Zips files into one zipfile per half-year, drawing on the file list provided by EIA. 
- Adds a CSV validation method. 
- Adds DOIs to `dataset.doi`
- Adds archive to GHA
- Switch from `2018h1` to `2018half1` for partition to avoid confusion with "hours" shorthand

# Testing

How did you make sure this worked? How can a reviewer verify this?
Review [sandbox archive](https://sandbox.zenodo.org/records/38410) and [draft production archive](https://zenodo.org/records/10840078?preview=1), attempt to make archive.

# To-do list

```[tasklist]
- [x] Get feedback on CSV validation method
- [x] Make production archive and add to `dataset_doi.yaml`
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
