### PR TITLE
Stop generating deprecated `remote_url` metadata field.

### DIFF
--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -81,7 +81,6 @@ class Resource(BaseModel):
     profile: str = "data-resource"
     name: str
     path: Url
-    remote_url: Url
     title: str
     parts: dict[str, Any]
     encoding: str = "utf-8"
@@ -104,7 +103,6 @@ class Resource(BaseModel):
         return cls(
             name=file.filename,
             path=file.links.canonical,
-            remote_url=file.links.canonical,
             title=filename.name,
             mediatype=mt,
             parts=parts,

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -428,7 +428,6 @@ class DepositionOrchestrator:
             if field == "resources":
                 for r in old_datapackage.resources + new_datapackage.resources:
                     r.path = re.sub(r"/\d+/", "/ID_NUMBER/", str(r.path))
-                    r.remote_url = re.sub(r"/\d+/", "/ID_NUMBER/", str(r.remote_url))
             if getattr(new_datapackage, field) != getattr(old_datapackage, field):
                 return True
         return False

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -52,7 +52,6 @@ def _resource_w_size(name: str, size: int):
     return Resource(
         name=name,
         path=f"https://www.example.com/{name}",
-        remote_url="https://www.example.com",
         title="",
         parts={},
         mediatype="",
@@ -67,7 +66,6 @@ def _resource_w_parts(name: str, parts: dict):
     return Resource(
         name=name,
         path=f"https://www.example.com/{name}",
-        remote_url="https://www.example.com",
         title="",
         parts=parts,
         mediatype="",

--- a/tests/unit/archive_validate_test.py
+++ b/tests/unit/archive_validate_test.py
@@ -68,7 +68,6 @@ def _fake_resource(num=0, **kwargs):
     params = {
         "name": f"resource{num}",
         "path": "https://www.fake.link",
-        "remote_url": "https://www.fake.link",
         "title": f"Resource {num}",
         "parts": {},
         "mediatype": "zip",


### PR DESCRIPTION
# Overview

We no longer use the `remote_url` field in our archives, and instead leave the `path` field pristine and infer the local paths, so we should stop inserting the cruft into new archives.

# Testing

- I removed the `remote_url` field from my handmade `gridpathratk` archive and it worked fine.

# To-do list

```[tasklist]
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
