### PR TITLE
Fix failing FERC archivers

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -26,6 +26,11 @@ jobs:
           - eiawater
           - eia_bulk_elec
           - epacamd_eia
+          - ferc1
+          - ferc2
+          - ferc6
+          - ferc60
+          - ferc714
           - mshamines
           - nrelatb
           - phmsagas

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -228,7 +228,7 @@ async def archive_taxonomy(
     taxonomy = await retry_async(
         asyncio.to_thread,
         args=[ModelXbrl.load, model_manager, taxonomy_entry_point],
-        retry_on=(FileNotFoundError,),
+        retry_on=(FileNotFoundError, FileExistsError),
     )
 
     archive_path = output_dir / f"ferc{form_number}-xbrl-taxonomy-{year}.zip"
@@ -294,7 +294,7 @@ async def archive_year(
             try:
                 response = await retry_async(
                     session.get,
-                    args=[filing.download_url],
+                    args=[str(filing.download_url)],
                     kwargs={"raise_for_status": True},
                 )
                 response_bytes = await retry_async(response.content.read)


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #285 .

What problem does this address?

FERC archivers were failing with

```
TypeError: Constructor parameter should be str
```

Which we thought was related to some other error messages earlier about

```
Unsuccessful renaming of downloaded file to active file /Users/dazhong-catalyst/Library/Caches/Arelle/https/ecollection.ferc.gov/taxonomy/form60/2022-01-01/schedules/ScheduleTemporaryCashInvestments/sched-105_2022-01-01_pre.xml                             
Please remove with file manager.
```

But actually *those* errors were due to concurrency issues with arelle, and we already handled them with retries. The true issue was that `aiohttp.ClientSession.get()` wants a `str` or [`yarl.URL`](https://yarl.aio-libs.org/en/stable/api/#yarl.URL) which is different from the `pydantic.networks.HttpUrl` that we were passing in. Oops!

What did you change in this PR?

Coerce that bad boy to a string.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```
pudl_archiver --datasets ferc60 --sandbox --only-years 2022
```

On main, it fails. On this branch, it succeeds. Et voilà.