### PR TITLE
Update to use Python 3.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
   - defaults
 dependencies:
   # Used to set up the environment
-  - pip>=21,<24
-  - python>=3.11,<3.12
+  - pip>=21,<25
+  - python>=3.12,<3.13
   - setuptools>=66
   # fiona is a transitive dependency which needs GDAL. so we install with conda
   # TODO: we shouldn't have to install all this geo stuff, so once we break the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pudl_archiver"
 version = "0.2.0"
 authors = [{name = "PUDL", email = "pudl@catalyst.coop"}]
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.12,<3.13"
 
 dependencies = [
     "arelle-release>=2.3,<2.25",
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 
@@ -91,8 +91,8 @@ doctest_optionflags = [
 ]
 
 [tool.ruff]
-# Assume Python 3.11
-target-version = "py311"
+# Assume Python 3.12
+target-version = "py312"
 line-length = 88
 indent-width = 4
 

--- a/tests/unit/archive_base_test.py
+++ b/tests/unit/archive_base_test.py
@@ -207,7 +207,7 @@ async def test_download_file(mocker, tmp_path):
     def _ground_truth_download(url):
         return requests.get(url, timeout=1000).content
 
-    url = "https://github.com/catalyst-cooperative/pudl-archiver/blob/main/README.md"
+    url = "https://raw.githubusercontent.com/catalyst-cooperative/pudl-archiver/main/README.md"
     file_content = _ground_truth_download(url)
 
     # Initialize MockArchiver class


### PR DESCRIPTION
# Overview

Update the PUDL archivers to use Python 3.12, so they are compatible with the main PUDL package.

Currently one failing test.... not sure why!
```console
pytest tests/unit/archive_base_test.py::test_download_file
```

```py
    @pytest.mark.asyncio
    async def test_download_file(mocker, tmp_path):
        """Test download_file.

        Tests that expected data is written to file on disk or in memory. We use Catalyst's
        README.md file to ensure that downloads produce the same content as a direct GET.
        """

        def _ground_truth_download(url):
            return requests.get(url, timeout=1000).content

        url = "https://github.com/catalyst-cooperative/pudl-archiver/blob/main/README.md"
        file_content = _ground_truth_download(url)

        # Initialize MockArchiver class
        archiver = MockArchiver(None)

        async with ClientSession() as session:
            archiver.session = session
            file = io.BytesIO()

            # Call method
            await archiver.download_file(url, file)
>           assert file.getvalue() == file_content
```
```
E           assert b'\n\n\n\n\n\...\n</html>\n\n' == b'\n\n\n\n\n\...\n</html>\n\n'
E
E             At index 16350 diff: b'A' != b'2'
E
E             Full diff:
E               (b'\n\n\n\n\n\n<!DOCTYPE html>\n<html\n  lang="en"\n  \n  data-color-mode="au'
E                b'to" data-light-theme="light" data-dark-theme="dark"\n  data-a11y-animated'
E                b'-images="system" data-a11y-link-underlines="true"\n  >\n\n\n\n\n  <head>\n '...
E
E             ...Full output truncated (5865 lines hidden), use '-vv' to show
```

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
