### PR TITLE
Update issue templates for monthly dataset review

### DIFF
--- a/.github/ISSUE_TEMPLATE/monthly-archive-update.md
+++ b/.github/ISSUE_TEMPLATE/monthly-archive-update.md
@@ -1,0 +1,53 @@
+---
+name: Monthly archive update
+about: Template for publishing monthly archives.
+title: Publish archives for the month of MONTH
+labels: automation, zenodo
+assignees: ''
+
+---
+
+# Review and publish archives
+
+For each of the following archives, find the run status in the Github archiver run. If approved, manually review the archive and publish. Then check the box here to confirm publication status:
+
+```[tasklist]
+- [ ] eia176
+- [ ] eia191
+- [ ] eia757a
+- [ ] eia860
+- [ ] eia860m
+- [ ] eia861
+- [ ] eia923
+- [ ] eia930
+- [ ] eiaaeo
+- [ ] eiawater
+- [ ] eia_bulk_elec
+- [ ] epacamd_eia
+- [ ] ferc1
+- [ ] ferc2
+- [ ] ferc6
+- [ ] ferc60
+- [ ] ferc714
+- [ ] mshamines
+- [ ] nrelatb
+- [ ] phmsagas
+- [ ] epacems
+```
+
+# Validation failures
+For each run that failed because of validation test failures (seen in the GHA logs), add it to the tasklist. Download the run summary JSON by going into the "Upload run summaries" tab of the GHA run for each dataset, and follow the link. Investigate the validation failure, and make an issue to resolve it.
+
+```[tasklist]
+- [ ]
+```
+
+# Other failures
+For each run that failed because of another reason (e.g., underlying data changes, code failures), create an issue describing the failure and take necessary steps to resolve it.
+
+```[tasklist]
+- [ ]
+```
+
+# Relevant logs
+[Link to logs from GHA run]( PLEASE FIND THE ACTUAL LINK AND FILL IN HERE )

--- a/.github/ISSUE_TEMPLATE/monthly-archive-update.md
+++ b/.github/ISSUE_TEMPLATE/monthly-archive-update.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Review and publish archives
 
-For each of the following archives, find the run status in the Github archiver run. If approved, manually review the archive and publish. Then check the box here to confirm publication status:
+For each of the following archives, find the run status in the Github archiver run. If validation tests pass, manually review the archive and publish. If no changes detected, delete the draft. If changes are detected, manually review the archive following the guidelines in step 3 of `README.md`, then publish the new version. Then check the box here to confirm publication status, adding a note on the status (e.g., "v1 published", "no changes detected, draft deleted"):
 
 ```[tasklist]
 - [ ] eia176
@@ -36,10 +36,14 @@ For each of the following archives, find the run status in the Github archiver r
 ```
 
 # Validation failures
-For each run that failed because of validation test failures (seen in the GHA logs), add it to the tasklist. Download the run summary JSON by going into the "Upload run summaries" tab of the GHA run for each dataset, and follow the link. Investigate the validation failure, and make an issue to resolve it.
+For each run that failed because of validation test failures (seen in the GHA logs), add it to the tasklist. Download the run summary JSON by going into the "Upload run summaries" tab of the GHA run for each dataset, and follow the link. Investigate the validation failure.
+
+If the validation failure is deemed ok after manual review (e.g., Q2 of 2024 data doubles the size of a file that only had Q1 data previously, but the new data looks as expected), go ahead and approve the archive and leave a note explaining your decision in the task list.
+
+If the validation failure is blocking (e.g., file format incorrect, whole dataset changes size by 200%), make an issue to resolve it.
 
 ```[tasklist]
-- [ ]
+- [ ] dataset
 ```
 
 # Other failures


### PR DESCRIPTION
Make monthly archive updates faster by creating a template for review. The next step will be to connect this to the GHA so this issue is automatically created after each monthly run.

See #314 for an example of how this looks as a rendered issue.