### PR TITLE
Update PHMSA sandbox doi and fix PHMSA archiver

### DIFF
--- a/dataset_doi.yaml
+++ b/dataset_doi.yaml
@@ -63,4 +63,4 @@ nrelatb:
   sandbox_doi: 10.5072/zenodo.38192
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
-  sandbox_doi: 10.5072/zenodo.3357
+  sandbox_doi: 10.5072/zenodo.45279


### PR DESCRIPTION
# Overview

Closes #319

What problem does this address?
Fixes download failure due to double slash, and handles `2023_DELAYED.xlsx` file format by updating `file_years` method to use regex instead of split.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run the PHMSA archiver.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
