### PR TITLE
Update pudl-archiver to use Frictionless v5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ authors = [{name = "PUDL", email = "pudl@catalyst.coop"}]
 requires-python = ">=3.12,<3.13"
 
 dependencies = [
-    "arelle-release>=2.3,<2.26",
-    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
+    "arelle-release>=2.25,<2.26",
+    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git@frictionless-5",
     "coloredlogs>=14",
     "dask<2024.5",  # Temporary pin -- conda packaging problem upstream
     "feedparser>=6.0",
-    "frictionless>=4.40,<5",
-    "pydantic>=2.0,<3",
+    "frictionless>=5,<6",
+    "pydantic>=2.7,<3",
     "python-dotenv~=1.0.0",
     "semantic_version>=2.8,<3",
     "tqdm>=4.64",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12,<3.13"
 
 dependencies = [
     "arelle-release>=2.25,<2.26",
-    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git@frictionless-5",
+    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
     "coloredlogs>=14",
     "dask<2024.5",  # Temporary pin -- conda packaging problem upstream
     "feedparser>=6.0",

--- a/tests/unit/frictionless_test.py
+++ b/tests/unit/frictionless_test.py
@@ -35,4 +35,4 @@ def test_datapackage():
         "ferc1", deposition_files, resources, version="1.0.0"
     )
 
-    assert Package(descriptor=dp.model_dump(by_alias=True)).metadata_valid
+    assert Package.validate_descriptor(dp.model_dump(by_alias=True)).valid


### PR DESCRIPTION
# Overview

* A step toward https://github.com/catalyst-cooperative/pudl/issues/3293
* Update to `frictionless>=5,<6` and make minor syntax adjustments related to datapackage descriptor validation.
* Note that the draft PR points at the `frictionless-5` branch of PUDL to verify that everything is working. When https://github.com/catalyst-cooperative/pudl/pull/3569 is merged this pointer should revert to pointing at the `main` branch of PUDL.

# Testing

* Unfortunately the Zenodo Sandbox is giving 500 Server Errors right now when we attempt to download an existing record ID, but that's independent of this PR.
* All the other tests seem to pass.

# To-do list

```[tasklist]
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
