### PR TITLE
Fix concurrency issues with XBRL taxonomy archiving

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -58,63 +58,10 @@ jobs:
           name: run-summaries-${{ matrix.dataset }}
           path: ${{ matrix.dataset }}_run_summary.json
 
-  archive-run-large:
-    defaults:
-      run:
-        shell: bash -l {0}
-    strategy:
-      matrix:
-        dataset:
-          - epacems
-      fail-fast: false
-    runs-on:
-      group: large-runner-group
-      labels: ubuntu-22.04-4core
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Conda environment using mamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: environment.yml
-          cache-environment: true
-          condarc: |
-            channels:
-            - conda-forge
-            - defaults
-            channel_priority: strict
-
-      - name: Log the conda environment
-        run: |
-          conda info
-          conda list
-          conda config --show-sources
-          conda config --show
-          printenv | sort
-
-      - name: Run archiver for ${{ matrix.dataset }}
-        env:
-          ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
-          ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
-          EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
-          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
-          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
-        run: |
-          pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
-
-      - name: Upload run summaries
-        if: failure() || success()
-        id: upload_summaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: run-summaries-${{ matrix.dataset }}
-          path: ${{ matrix.dataset }}_run_summary.json
-
   archive-notify:
     runs-on: ubuntu-latest
     needs:
       - archive-run-small
-      - archive-run-large
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -14,7 +14,26 @@ jobs:
     strategy:
       matrix:
         dataset:
+          - eia176
+          - eia191
+          - eia757a
+          - eia860
+          - eia861
+          - eia860m
+          - eia923
+          - eia930
+          - eiaaeo
+          - eiawater
+          - eia_bulk_elec
+          - epacamd_eia
           - ferc1
+          - ferc2
+          - ferc6
+          - ferc60
+          - ferc714
+          - mshamines
+          - nrelatb
+          - phmsagas
 
       fail-fast: false
     runs-on: ubuntu-latest
@@ -58,10 +77,63 @@ jobs:
           name: run-summaries-${{ matrix.dataset }}
           path: ${{ matrix.dataset }}_run_summary.json
 
+  archive-run-large:
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        dataset:
+          - epacems
+      fail-fast: false
+    runs-on:
+      group: large-runner-group
+      labels: ubuntu-22.04-4core
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Conda environment using mamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
+
+      - name: Log the conda environment
+        run: |
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+
+      - name: Run archiver for ${{ matrix.dataset }}
+        env:
+          ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
+          ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+          EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
+          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
+          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
+        run: |
+          pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
+
+      - name: Upload run summaries
+        if: failure() || success()
+        id: upload_summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-summaries-${{ matrix.dataset }}
+          path: ${{ matrix.dataset }}_run_summary.json
+
   archive-notify:
     runs-on: ubuntu-latest
     needs:
       - archive-run-small
+      - archive-run-large
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -14,26 +14,7 @@ jobs:
     strategy:
       matrix:
         dataset:
-          - eia176
-          - eia191
-          - eia757a
-          - eia860
-          - eia861
-          - eia860m
-          - eia923
-          - eia930
-          - eiaaeo
-          - eiawater
-          - eia_bulk_elec
-          - epacamd_eia
           - ferc1
-          - ferc2
-          - ferc6
-          - ferc60
-          - ferc714
-          - mshamines
-          - nrelatb
-          - phmsagas
 
       fail-fast: false
     runs-on: ubuntu-latest

--- a/src/pudl_archiver/archivers/ferc/ferc1.py
+++ b/src/pudl_archiver/archivers/ferc/ferc1.py
@@ -14,7 +14,6 @@ class Ferc1Archiver(AbstractDatasetArchiver):
     """Ferc Form 1 archiver."""
 
     name = "ferc1"
-    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 1 resources."""
@@ -23,16 +22,20 @@ class Ferc1Archiver(AbstractDatasetArchiver):
                 yield self.get_year_dbf(year)
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_1]
+        taxonomy_years = []
         for year, year_filings in filings.items():
             if self.valid_year(year):
                 if year > 2019:
-                    yield xbrl.archive_taxonomy(
-                        year,
-                        xbrl.FercForm.FORM_1,
-                        self.download_directory,
-                        self.session,
-                    )
+                    taxonomy_years.append(year)
                 yield self.get_year_xbrl(year, year_filings)
+
+        if len(taxonomy_years) > 0:
+            yield xbrl.archive_taxonomy(
+                taxonomy_years,
+                xbrl.FercForm.FORM_1,
+                self.download_directory,
+                self.session,
+            )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc1.py
+++ b/src/pudl_archiver/archivers/ferc/ferc1.py
@@ -14,6 +14,7 @@ class Ferc1Archiver(AbstractDatasetArchiver):
     """Ferc Form 1 archiver."""
 
     name = "ferc1"
+    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 1 resources."""

--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -32,14 +32,21 @@ class Ferc2Archiver(AbstractDatasetArchiver):
 
         # Get XBRL filings
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_2]
+        taxonomy_years = []
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield xbrl.archive_taxonomy(
-                    year, xbrl.FercForm.FORM_2, self.download_directory, self.session
-                )
+                taxonomy_years.append(year)
             yield self.get_year_xbrl(year, year_filings)
+
+        if len(taxonomy_years) > 0:
+            yield xbrl.archive_taxonomy(
+                taxonomy_years,
+                xbrl.FercForm.FORM_2,
+                self.download_directory,
+                self.session,
+            )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -23,14 +23,18 @@ class Ferc6Archiver(AbstractDatasetArchiver):
             yield self.get_year_dbf(year)
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_6]
+        taxonomy_years = []
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield xbrl.archive_taxonomy(
-                    year, xbrl.FercForm.FORM_6, self.download_directory, self.session
-                )
+                taxonomy_years.append(year)
             yield self.get_year_xbrl(year, year_filings)
+
+        if len(taxonomy_years) > 0:
+            yield xbrl.archive_taxonomy(
+                year, xbrl.FercForm.FORM_6, self.download_directory, self.session
+            )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -23,14 +23,21 @@ class Ferc60Archiver(AbstractDatasetArchiver):
             yield self.get_year_dbf(year)
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_60]
+        taxonomy_years = []
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield xbrl.archive_taxonomy(
-                    year, xbrl.FercForm.FORM_60, self.download_directory, self.session
-                )
+                taxonomy_years.append(year)
             yield self.get_year_xbrl(year, year_filings)
+
+        if len(taxonomy_years) > 0:
+            yield xbrl.archive_taxonomy(
+                taxonomy_years,
+                xbrl.FercForm.FORM_60,
+                self.download_directory,
+                self.session,
+            )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -20,14 +20,18 @@ class Ferc714Archiver(AbstractDatasetArchiver):
         yield self.get_bulk_csv()
 
         filings = xbrl.index_available_entries()[xbrl.FercForm.FORM_714]
+        taxonomy_years = []
         for year, year_filings in filings.items():
             if not self.valid_year(year):
                 continue
             if year > 2019:
-                yield xbrl.archive_taxonomy(
-                    year, xbrl.FercForm.FORM_714, self.download_directory, self.session
-                )
+                taxonomy_years.append(year)
             yield self.get_year_xbrl(year, year_filings)
+
+        if len(taxonomy_years) > 0:
+            yield xbrl.archive_taxonomy(
+                year, xbrl.FercForm.FORM_714, self.download_directory, self.session
+            )
 
     async def get_year_xbrl(
         self, year: int, filings: xbrl.FormFilings

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -312,6 +312,7 @@ async def archive_year(
             # Check if file is in zipfile already
             if filename in archive.namelist():
                 if zlib.crc32(response_bytes) != archive.getinfo(filename).CRC:
+                    logger.info(f"{filings}")
                     raise RuntimeError(
                         f"{year}: {filing} is duplicate with different content."
                     )

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -175,7 +175,7 @@ def index_available_entries() -> dict[FercForm, FormFilings]:
             if "Test" in entry["title"]:
                 continue
 
-            parsed_entry = FeedEntry(**entry, feed_link=feed)
+            parsed_entry = FeedEntry(**entry)
 
             # Get filings specific to FERC form and append new filing
             indexed_form = indexed_filings[parsed_entry.ferc_formname]

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -175,7 +175,7 @@ def index_available_entries() -> dict[FercForm, FormFilings]:
             if "Test" in entry["title"]:
                 continue
 
-            parsed_entry = FeedEntry(**entry)
+            parsed_entry = FeedEntry(**entry, feed_link=feed)
 
             # Get filings specific to FERC form and append new filing
             indexed_form = indexed_filings[parsed_entry.ferc_formname]

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -312,7 +312,9 @@ async def archive_year(
             # Check if file is in zipfile already
             if filename in archive.namelist():
                 if zlib.crc32(response_bytes) != archive.getinfo(filename).CRC:
-                    raise RuntimeError(f"{filing} is duplicate with different content.")
+                    raise RuntimeError(
+                        f"{year}: {filing} is duplicate with different content."
+                    )
                 logger.info("True duplicate files")
                 continue
 


### PR DESCRIPTION
This PR fixes the broken XBRL taxonomy archives by removing concurrency for all taxonomy downloads. It does this by slightly modifying the archiver base class, so now instead of only returning a single `ResourceInfo` object from download tasks, you can also return a `list[ResourceInfo]` and the base class will iterate through all of these resources and handle them appropriately. It also changes the `xbrl` archiver code to use this interface by changing the `archive_taxonomy` function to only be called once and it will download all years of the taxonomy synchronously.
