### PR TITLE
Fix auto publish and ferc 6/714 archivers

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -33,7 +33,10 @@ class Ferc6Archiver(AbstractDatasetArchiver):
 
         if len(taxonomy_years) > 0:
             yield xbrl.archive_taxonomy(
-                year, xbrl.FercForm.FORM_6, self.download_directory, self.session
+                taxonomy_years,
+                xbrl.FercForm.FORM_6,
+                self.download_directory,
+                self.session,
             )
 
     async def get_year_xbrl(

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -30,7 +30,10 @@ class Ferc714Archiver(AbstractDatasetArchiver):
 
         if len(taxonomy_years) > 0:
             yield xbrl.archive_taxonomy(
-                year, xbrl.FercForm.FORM_714, self.download_directory, self.session
+                taxonomy_years,
+                xbrl.FercForm.FORM_714,
+                self.download_directory,
+                self.session,
             )
 
     async def get_year_xbrl(

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -269,6 +269,7 @@ class DraftDeposition(BaseModel, ABC):
             )
             return None
 
+        logger.info("Attempting to publish deposition.")
         return await self.publish()
 
     async def _apply_change(self, change: DepositionChange) -> "DraftDeposition":

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -249,7 +249,6 @@ class DraftDeposition(BaseModel, ABC):
         self, run_summary: RunSummary, datapackage_updated: bool, auto_publish: bool
     ) -> PublishedDeposition | None:
         """Check that deposition is valid and worth changing, then publish if so."""
-        logger.info("Attempting to publish deposition.")
         if not run_summary.success:
             logger.error(
                 "Archive validation failed. Not publishing new archive, kept "

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -246,7 +246,7 @@ class DraftDeposition(BaseModel, ABC):
         return await self._apply_change(change)
 
     async def publish_if_valid(
-        self, run_summary: RunSummary, datapackage_updated: bool
+        self, run_summary: RunSummary, datapackage_updated: bool, auto_publish: bool
     ) -> PublishedDeposition | None:
         """Check that deposition is valid and worth changing, then publish if so."""
         logger.info("Attempting to publish deposition.")
@@ -262,6 +262,13 @@ class DraftDeposition(BaseModel, ABC):
                 f"{self.get_deposition_link()} for inspection."
             )
             return None
+        if not auto_publish:
+            logger.info(
+                "Skipping publishing because auto-publish is disabled, kept draft at "
+                f"{self.get_deposition_link()} for inspection."
+            )
+            return None
+
         return await self.publish()
 
     async def _apply_change(self, change: DepositionChange) -> "DraftDeposition":

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -48,5 +48,7 @@ async def orchestrate_run(
         validations,
         draft.get_deposition_link(),
     )
-    published = await draft.publish_if_valid(summary, datapackage_updated)
+    published = await draft.publish_if_valid(
+        summary, datapackage_updated, run_settings.auto_publish
+    )
     return summary, published


### PR DESCRIPTION
This PR cleans up some minor bugs introduced in recent changes. It fixes auto-publishing behavior, which was publishing even when disabled, and fixes ferc 6/714 archivers, which were calling the `archive_taxonomy` function slightly incorrectly.
