### PR TITLE
Remove --dry-run CLI option and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ There are also four optional flags available:
 - `--initialize`: used for creating an archive for a new dataset that doesn't
   currently exist on zenodo. If successful, this command will automatically add
   the new Zenodo DOI to the `dataset_doi.yaml` file.
-- `--dry-run`: used for testing, it ignores all Zenodo write operations.
 - `--all`: shortcut for archiving all datasets that we have defined archivers
   for. Overrides `--datasets`.
 

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -48,11 +48,6 @@ def parse_main(args=None):
         help="Initialize new deposition by preserving a DOI",
     )
     parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Skip actually uploading to Zenodo",
-    )
-    parser.add_argument(
         "--summary-file",
         type=Path,
         help="Generate a JSON archive run summary",

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -278,10 +278,6 @@ class DraftDeposition(BaseModel, ABC):
             draft: the draft to make these changes to
             change: the change to make
         """
-        if self.settings.dry_run:
-            logger.info(f"Dry run, skipping {change}")
-            return None
-
         draft = self
         if change.action_type in [DepositionAction.DELETE, DepositionAction.UPDATE]:
             draft = await self.delete_file(change.name)

--- a/src/pudl_archiver/utils.py
+++ b/src/pudl_archiver/utils.py
@@ -125,7 +125,6 @@ class RunSettings(BaseModel):
     sandbox: bool = True
     initialize: bool = False
     only_years: list[int] | None = []
-    dry_run: bool = True
     summary_file: Path | None = None
     download_dir: str | None = None
     auto_publish: bool = False

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -155,7 +155,6 @@ async def test_zenodo_workflow(
     )
 
     settings = RunSettings(
-        dry_run=False,
         sandbox=True,
         auto_publish=False,
         refresh_metadata=False,


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #208.

What problem does this address?

The `--dry-run` option does not adequately simulate running the archiver, so it's better to rely on the `--auto-publish` option.

What did you change in this PR?

I removed all references to the --dry-run option.

# Testing

How did you make sure this worked? How can a reviewer verify this?

To find all references to the flag I searched the repository for "dry".

I was not able to run any tests because the dependencies currently have a conflict. This repo stipulates `"ruff>=0.3,<0.4"` but the `pudl` repository [recently](https://github.com/catalyst-cooperative/pudl/commit/5806b46c7c5efe367bb06045d78417f9c51c3134) updated `ruff` to 4.1.

Let me know if there are any testing steps I should take!

# To-do list

```[tasklist]
- [x] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
