### PR TITLE
Fix datapackage errors and FERC failures

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferc1.py
+++ b/src/pudl_archiver/archivers/ferc/ferc1.py
@@ -14,6 +14,7 @@ class Ferc1Archiver(AbstractDatasetArchiver):
     """Ferc Form 1 archiver."""
 
     name = "ferc1"
+    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 1 resources."""

--- a/src/pudl_archiver/archivers/ferc/ferc6.py
+++ b/src/pudl_archiver/archivers/ferc/ferc6.py
@@ -14,6 +14,7 @@ class Ferc6Archiver(AbstractDatasetArchiver):
     """FERC Form 6 archiver."""
 
     name = "ferc6"
+    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 6 resources."""

--- a/src/pudl_archiver/archivers/ferc/ferc60.py
+++ b/src/pudl_archiver/archivers/ferc/ferc60.py
@@ -14,6 +14,7 @@ class Ferc60Archiver(AbstractDatasetArchiver):
     """Ferc Form 60 archiver."""
 
     name = "ferc60"
+    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 60 resources."""

--- a/src/pudl_archiver/archivers/ferc/ferc714.py
+++ b/src/pudl_archiver/archivers/ferc/ferc714.py
@@ -14,6 +14,7 @@ class Ferc714Archiver(AbstractDatasetArchiver):
     """Ferc Form 714 archiver."""
 
     name = "ferc714"
+    concurrency_limit = 1
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download FERC 714 resources."""

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -309,6 +309,10 @@ class DraftDeposition(BaseModel, ABC):
     def _datapackage_worth_changing(
         self, old_datapackage: DataPackage | None, new_datapackage: DataPackage
     ) -> bool:
+        # Copy datapackages so we can modify without causing problems down the line
+        new_datapackage = new_datapackage.model_copy(deep=True)
+        if old_datapackage is not None:
+            old_datapackage = old_datapackage.model_copy(deep=True)
         # ignore differences in created/version
         # ignore differences resource paths if it's just some ID number changing...
         if old_datapackage is None:
@@ -336,9 +340,7 @@ class DraftDeposition(BaseModel, ABC):
 
         # Add datapackage if it's changed
         # copy new datapackage so temporary modifications aren't saved
-        if update := self._datapackage_worth_changing(
-            old_datapackage.model_copy(deep=True), new_datapackage.model_copy(deep=True)
-        ):
+        if update := self._datapackage_worth_changing(old_datapackage, new_datapackage):
             datapackage_json = io.BytesIO(
                 bytes(
                     new_datapackage.model_dump_json(by_alias=True, indent=4),

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -324,10 +324,7 @@ class DraftDeposition(BaseModel, ABC):
 
         # Due to a bug in an earlier version some resources ended up with ID_NUMBER in path.
         # These should be replaced
-        for r in old_datapackage.resources:
-            if "ID_NUMBER" in r.path:
-                return True
-        return False
+        return any("ID_NUMBER" in r.path for r in old_datapackage.resources)
 
     async def attach_datapackage(
         self,
@@ -339,7 +336,9 @@ class DraftDeposition(BaseModel, ABC):
 
         # Add datapackage if it's changed
         # copy new datapackage so temporary modifications aren't saved
-        if update := self._datapackage_worth_changing(old_datapackage, new_datapackage.model_copy(deep=True)):
+        if update := self._datapackage_worth_changing(
+            old_datapackage, new_datapackage.model_copy(deep=True)
+        ):
             datapackage_json = io.BytesIO(
                 bytes(
                     new_datapackage.model_dump_json(by_alias=True, indent=4),

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -337,7 +337,7 @@ class DraftDeposition(BaseModel, ABC):
         # Add datapackage if it's changed
         # copy new datapackage so temporary modifications aren't saved
         if update := self._datapackage_worth_changing(
-            old_datapackage, new_datapackage.model_copy(deep=True)
+            old_datapackage.model_copy(deep=True), new_datapackage.model_copy(deep=True)
         ):
             datapackage_json = io.BytesIO(
                 bytes(

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -310,20 +310,24 @@ class DraftDeposition(BaseModel, ABC):
         self, old_datapackage: DataPackage | None, new_datapackage: DataPackage
     ) -> bool:
         # Copy datapackages so we can modify without causing problems down the line
-        new_datapackage = new_datapackage.model_copy(deep=True)
+        new_datapackage_copy = new_datapackage.model_copy(deep=True)
         if old_datapackage is not None:
-            old_datapackage = old_datapackage.model_copy(deep=True)
+            old_datapackage_copy = old_datapackage.model_copy(deep=True)
         # ignore differences in created/version
         # ignore differences resource paths if it's just some ID number changing...
         if old_datapackage is None:
             return True
-        for field in new_datapackage.model_dump():
+        for field in new_datapackage_copy.model_dump():
             if field in {"created", "version"}:
                 continue
             if field == "resources":
-                for r in old_datapackage.resources + new_datapackage.resources:
+                for r in (
+                    old_datapackage_copy.resources + new_datapackage_copy.resources
+                ):
                     r.path = re.sub(r"/\d+/", "/ID_NUMBER/", str(r.path))
-            if getattr(new_datapackage, field) != getattr(old_datapackage, field):
+            if getattr(new_datapackage_copy, field) != getattr(
+                old_datapackage_copy, field
+            ):
                 return True
 
         # Due to a bug in an earlier version some resources ended up with ID_NUMBER in path.

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -332,7 +332,7 @@ class DraftDeposition(BaseModel, ABC):
 
         # Due to a bug in an earlier version some resources ended up with ID_NUMBER in path.
         # These should be replaced
-        return any("ID_NUMBER" in r.path for r in old_datapackage.resources)
+        return any("ID_NUMBER" in str(r.path) for r in old_datapackage.resources)
 
     async def attach_datapackage(
         self,

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -260,6 +260,8 @@ async def test_zenodo_workflow(
 
     # Should fail due to deleted file
     downloader = TestDownloader(v2_resources, session=session)
+    downloader.fail_on_file_size_change = False
+    downloader.fail_on_dataset_size_change = False
     v2_summary, v2_refreshed = await orchestrate_run(
         dataset="pudl_test",
         downloader=downloader,


### PR DESCRIPTION
This PR addresses issues discovered while trying to publish new archives outlined in [this](https://github.com/catalyst-cooperative/pudl-archiver/issues/336) issue. Specifically, it addresses problems with the `datapackage.json` files generated during this run, and problems with the FERC archivers. The datapackage issues arose fromrecent updates that caused us to accidentally overwrite values in the file causing there to be bad links for resources within the archive. The [FERC issue](https://github.com/catalyst-cooperative/pudl-archiver/issues/338) came up when we started occasionally getting errors where we would get a webpage that appeared to be a logon while trying to archive taxonomy files. This appears to be a rate limiting mechanism, and by reducing concurrency, we were able to avoid this issue in [this](https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/8944169648/job/24570507508) archiver run.