### PR TITLE
Bump GDAL to 3.9.0 explicitly to align with PUDL dependencies

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -21,7 +21,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
-          cache-environment: true
+          cache-environment: false
           cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
           condarc: |
             channels:

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -21,8 +21,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
-          #         cache-environment: false
-          #         cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
+          cache-environment: true
+          cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
           condarc: |
             channels:
             - conda-forge

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -21,12 +21,11 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
-          cache-environment: true
+          cache-environment: false
           cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
           condarc: |
             channels:
             - conda-forge
-            - defaults
             channel_priority: strict
 
       - name: Log conda environnment information

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -21,8 +21,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
-          cache-environment: false
-          cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
+          #         cache-environment: false
+          #         cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
           condarc: |
             channels:
             - conda-forge

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -21,7 +21,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml
-          cache-environment: false
+          cache-environment: true
           cache-environment-key: environment-${{ hashFiles('pyproject.toml') }}
           condarc: |
             channels:

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,6 @@ dependencies:
   # TODO: we shouldn't have to install all this geo stuff, so once we break the
   # dependency on `pudl` we should remove this too.
   - fiona>=1.9.5
+  - gdal>=3.9.0
   - pip:
       - --editable ./[dev,docs,tests]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12,<3.13"
 
 dependencies = [
     "arelle-release>=2.25,<2.28",
-    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
+    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git@gdal-3.9.0",
     "coloredlogs>=14",
     "dask<2024.6",  # Temporary pin -- conda packaging problem upstream
     "feedparser>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12,<3.13"
 
 dependencies = [
     "arelle-release>=2.25,<2.28",
-    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git@gdal-3.9.0",
+    "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
     "coloredlogs>=14",
     "dask<2024.6",  # Temporary pin -- conda packaging problem upstream
     "feedparser>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "arelle-release>=2.25,<2.28",
     "catalystcoop.pudl @ git+https://github.com/catalyst-cooperative/pudl.git",
     "coloredlogs>=14",
-    "dask<2024.6",  # Temporary pin -- conda packaging problem upstream
+    "dask>=2024",
     "feedparser>=6.0",
     "frictionless>=5,<6",
     "pydantic>=2.7,<3",

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
     pre-commit run --all-files --show-diff-on-failure name-tests-test
 
 [testenv:linters]
-description = Run the pre-commit, flake8 and bandit linters.
+description = Run the pre-commit and ruff linters.
 skip_install = false
 extras =
     {[testenv:pre_commit]extras}


### PR DESCRIPTION
# Overview

GDAL 3.9.0 has been out for a while, but the dependency between PUDL and the archivers kept us from updating.  Trying to resolve these incompatibilities in this PR.

I think that [the PUDL PR](https://github.com/catalyst-cooperative/pudl/pull/3668) updating the dependency needs to merge before the CI on this PR can pass.

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
