### PR TITLE
Remove outdated fiona dependency (as of geopandas v1.0)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,10 +7,9 @@ dependencies:
   - pip>=21,<25
   - python>=3.12,<3.13
   - setuptools>=66
-  # fiona is a transitive dependency which needs GDAL. so we install with conda
-  # TODO: we shouldn't have to install all this geo stuff, so once we break the
-  # dependency on `pudl` we should remove this too.
-  - fiona>=1.9.5
+  # GDAL is a transitive dependency whose binaries must match those installed by the
+  # pudl-dev conda environment, so we also install it with conda here.
+  # TODO: once we break the archiver repo's dependency on pudl we should remove this.
   - gdal>=3.9.0
   - pip:
       - --editable ./[dev,docs,tests]


### PR DESCRIPTION
# Overview

The main PUDL repo now requires `geopandas>=1.0` which does no longer depends on `fiona` so we don't need to install it in the conda environment for this repo anymore (hopefully all the other geospatial stuff behaves itself!)

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
