### PR TITLE
July data update: Move NREL ATB, include 2024 data, make AEO doi work

### DIFF
--- a/src/pudl_archiver/archivers/nrelatb.py
+++ b/src/pudl_archiver/archivers/nrelatb.py
@@ -20,7 +20,7 @@ class NrelAtbArchiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download NREL ATB resources."""
-        for year in range(2019, 2024):
+        for year in range(2019, 2025):
             if self.valid_year(year):
                 yield self.get_year_resource(year)
 

--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -26,7 +26,7 @@ eia930:
   production_doi: 10.5281/zenodo.10840077
   sandbox_doi: 10.5072/zenodo.38409
 eiaaeo:
-  production_doi: 10.5281/zenodo.10838487
+  production_doi: 10.5281/zenodo.10838488 # Temporary fix due to falsely deleted concept DOI
   sandbox_doi: 10.5072/zenodo.37746
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366


### PR DESCRIPTION
# Overview

Closes #369.

What problem does this address?
Updates NREL ATB and EIA AEO data from #369. Both records had a problem with concept DOIs marked as "deleted" incorrectly in the Zenodo API.

What did you change in this PR?
- Add 2024 NREL ATB data
- Move badly located NREL ATB archiver (out of EIA folder)
- Add temporary reference to the record rather than the troublesome deleted API for EIA AEO data, to enable future runs until issue is fixed.

# Testing

How did you make sure this worked? How can a reviewer verify this?
NREL archive is [here](https://zenodo.org/records/12609821).
You can try running either the AEO or NREL archivers, both should now work.

# To-do list

```[tasklist]
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
