### PR TITLE
Add GHA template to check early and final release data daily in release months, create issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/early-final-release-template.md
+++ b/.github/ISSUE_TEMPLATE/early-final-release-template.md
@@ -1,0 +1,39 @@
+---
+name: Early and final release archive updates
+about: Template for publishing early/final release EIA archives.
+title: Publish {{ date | date('MMMM Do YYYY') }} archives
+labels: automation, zenodo
+assignees: e-belfer
+
+---
+
+# Summary of results:
+See the job run logs and results [here]({{ env.RUN_URL }}).
+
+# Review and publish archives
+
+For each of the following archives, find the run status in the Github archiver run. If validation tests pass, manually review the archive and publish. If no changes detected, delete the draft. If changes are detected, manually review the archive following the guidelines in step 3 of `README.md`, then publish the new version. Then check the box here to confirm publication status, adding a note on the status (e.g., "v1 published", "no changes detected, draft deleted"):
+
+```[tasklist]
+- [ ] eia860
+- [ ] eia861
+- [ ] eia923
+```
+
+# Validation failures
+For each run that failed because of validation test failures (seen in the GHA logs), add it to the tasklist. Download the run summary JSON by going into the "Upload run summaries" tab of the GHA run for each dataset, and follow the link. Investigate the validation failure.
+
+If the validation failure is deemed ok after manual review (e.g., Q2 of 2024 data doubles the size of a file that only had Q1 data previously, but the new data looks as expected), go ahead and approve the archive and leave a note explaining your decision in the task list.
+
+If the validation failure is blocking (e.g., file format incorrect, whole dataset changes size by 200%), make an issue to resolve it.
+
+```[tasklist]
+- [ ] dataset
+```
+
+# Other failures
+For each run that failed because of another reason (e.g., underlying data changes, code failures), create an issue describing the failure and take necessary steps to resolve it.
+
+```[tasklist]
+- [ ] dataset
+```

--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -1,0 +1,122 @@
+---
+name: early-final-release-checker
+
+on:
+  workflow_dispatch:
+    inputs:
+      small_runner:
+        description: 'Small runner: Comma-separated list of datasets to archive (e.g., "ferc2","ferc6").'
+        # We can't pass env variables to the workflow_dispatch, so we manually list all small datasets here.
+        default: '"eia860m","eia861","eia923"'
+        required: true
+        type: string
+      create_github_issue:
+        description: "Create a Github issue from this run?"
+        default: false
+        required: true
+        type: boolean
+  schedule:
+    - cron: "21 8 2-31 6-7,9-10 *" # 8:21 AM UTC, every day in June, July, Sept, Oct except the 1st
+
+jobs:
+  archive-run-small:
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        # Note that we can't pass global env variables to the matrix, so we manually reproduce the list of datasets here.
+        dataset: ${{ fromJSON(format('[{0}]', inputs.small_runner || "eia860","eia861","eia923" )) }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Conda environment using mamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
+
+      - name: Log the conda environment
+        run: |
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+
+      - name: Run archiver for ${{ matrix.dataset }}
+        env:
+          ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
+          ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+          EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
+          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
+          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
+        run: |
+          pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
+
+      - name: Upload run summaries
+        if: always()
+        id: upload_summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-summaries-${{ matrix.dataset }}
+          path: ${{ matrix.dataset }}_run_summary.json
+
+  archive-notify:
+    runs-on: ubuntu-latest
+    needs:
+      - archive-run-small
+    if: ${{ always() }}
+    outputs:
+      output1: ${{ steps.all_summaries.outputs }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download summaries
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          pattern: run-summaries-*
+          merge-multiple: true
+      - name: show summaries
+        run: ls -R
+      - name: Munge summaries together
+        id: all_summaries
+        run: |
+          {
+            echo "SLACK_PAYLOAD<<EOF"
+            ./scripts/make_slack_notification_message.py --summary-files *_run_summary.json | tee slack-payload.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post update to pudl-deployment
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: "C03FHB9N0PQ"
+          payload: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+
+  make-github-issue:
+    runs-on: ubuntu-latest
+    needs:
+      - archive-run-small
+      - archive-notify
+    env:
+      OUTPUT1: ${{needs.archive-notify.outputs.output1}}
+      # If Slack message includes new data, create a Github issue
+    if: ${{ always() && (contains(OUTPUT1, "CREATE") || contains(OUTPUT1, "UPDATE") || inputs.create_github_issue == true) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create an issue
+        uses: JasonEtco/create-an-issue@v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/early-final-release-template.md


### PR DESCRIPTION
# Overview

Addresses first part of #372.

What problem does this address?
We currently don't have a regular way of checking what day ER and FR data are released. This PR makes a new GHA workflow that runs the archivers every day in June and July (looking for ER data) and September and October (looking for FR data). This currently only runs on 860, 861 and 923.

What did you change in this PR?
Made a new GHA workflow and corresponding issue template.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Once merged into main, we should run the workflow manually and check that it has kicked off the expected archives, and created the expected issue. We'll need to do this in order to be able to run the workflow without implementing some `on: push` workaround (e.g., as discussed [here](https://stackoverflow.com/questions/63362126/github-actions-how-can-i-run-a-workflow-created-on-a-non-master-branch-from-t?noredirect=1&lq=1#comment125886357_71057825)).

# To-do list

```[tasklist]
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
