### PR TITLE
Add ER prefix to 923 archiver

### DIFF
--- a/src/pudl_archiver/archivers/eia/eia923.py
+++ b/src/pudl_archiver/archivers/eia/eia923.py
@@ -19,7 +19,7 @@ class Eia923Archiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EIA-923 resources."""
-        link_pattern = re.compile(r"f((923)|(906920))_(\d{4})\.zip")
+        link_pattern = re.compile(r"f((923)|(906920))_(\d{4})(er)*\.zip")
 
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
             year = int(link_pattern.search(link).group(4))


### PR DESCRIPTION
# Overview

Closes first step of https://github.com/catalyst-cooperative/pudl/issues/3677.

What problem does this address?
EIA 923 data has an early release in July. The archiver currently doesn't capture files which include the early release prefix "er", unlike the EIA 860 and 861 archivers. This has caused a failure in this morning's archive run: https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/9870803976

What did you change in this PR?
Added the er prefix as an optional group in the 923 archiver regex.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See the draft EIA 923 archive in Zenodo.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
