### PR TITLE
Update EIA AEO DOI back to concept DOI

### DIFF
--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -26,7 +26,7 @@ eia930:
   production_doi: 10.5281/zenodo.10840077
   sandbox_doi: 10.5072/zenodo.38409
 eiaaeo:
-  production_doi: 10.5281/zenodo.10838488 # Temporary fix due to falsely deleted concept DOI
+  production_doi: 10.5281/zenodo.10838487
   sandbox_doi: 10.5072/zenodo.37746
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366


### PR DESCRIPTION
# Overview

What problem does this address?
In #370, we updated the AEO DOI to reference the latest record, rather than the concept DOI, which was incorrectly marked as "deleted" in Zenodo's API interface. This has now been fixed, and we should revert to using the concept DOI.

What did you change in this PR?
Updated the DOI in `zenodo_doi.yaml` back to the concept DOI.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Try to run `pudl_archiver --dataset eiaaeo --sandbox` and see if it works!

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
