### PR TITLE
Restore delete_deposition method, update AEO doi, sort FERC taxonomies

### DIFF
--- a/.github/ISSUE_TEMPLATE/early_release_checker.md
+++ b/.github/ISSUE_TEMPLATE/early_release_checker.md
@@ -1,0 +1,57 @@
+---
+name: Early release checker
+about: In the months of early release data, run archiver daily.
+title: Publish {{ date | date('MMMM Do YYYY') }} early release archives
+labels: automation, zenodo
+assignees: aesharpe
+
+---
+
+# Summary of results:
+See the job run logs and results [here]({{ env.RUN_URL }}).
+
+# Review and publish archives
+
+For each of the following archives, find the run status in the Github archiver run. If validation tests pass, manually review the archive and publish. If no changes detected, delete the draft. If changes are detected, manually review the archive following the guidelines in step 3 of `README.md`, then publish the new version. Then check the box here to confirm publication status, adding a note on the status (e.g., "v1 published", "no changes detected, draft deleted"):
+
+```[tasklist]
+- [ ] eia176
+- [ ] eia191
+- [ ] eia757a
+- [ ] eia860
+- [ ] eia860m
+- [ ] eia861
+- [ ] eia923
+- [ ] eia930
+- [ ] eiaaeo
+- [ ] eiawater
+- [ ] eia_bulk_elec
+- [ ] epacamd_eia
+- [ ] ferc1
+- [ ] ferc2
+- [ ] ferc6
+- [ ] ferc60
+- [ ] ferc714
+- [ ] mshamines
+- [ ] nrelatb
+- [ ] phmsagas
+- [ ] epacems
+```
+
+# Validation failures
+For each run that failed because of validation test failures (seen in the GHA logs), add it to the tasklist. Download the run summary JSON by going into the "Upload run summaries" tab of the GHA run for each dataset, and follow the link. Investigate the validation failure.
+
+If the validation failure is deemed ok after manual review (e.g., Q2 of 2024 data doubles the size of a file that only had Q1 data previously, but the new data looks as expected), go ahead and approve the archive and leave a note explaining your decision in the task list.
+
+If the validation failure is blocking (e.g., file format incorrect, whole dataset changes size by 200%), make an issue to resolve it.
+
+```[tasklist]
+- [ ] dataset
+```
+
+# Other failures
+For each run that failed because of another reason (e.g., underlying data changes, code failures), create an issue describing the failure and take necessary steps to resolve it.
+
+```[tasklist]
+- [ ] dataset
+```

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -64,7 +64,7 @@ jobs:
           ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
           ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         run: |
-          pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
+          pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
 
       - name: Upload run summaries
         if: always()
@@ -117,6 +117,7 @@ jobs:
           ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         run: |
           pudl_archiver --datasets ${{ matrix.dataset }} --summary-file ${{ matrix.dataset }}_run_summary.json
+        # Here we don't clobber the draft if it's unchanged, as it's far more labor intensive to recreate if needed!
 
       - name: Upload run summaries
         if: failure() || success()

--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -249,7 +249,7 @@ async def archive_taxonomies(
     taxonomy_versions = []
     archive_path = output_dir / f"ferc{form.as_int()}-xbrl-taxonomies.zip"
     with zipfile.ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
-        for taxonomy_entry_point in taxonomies_referenced:
+        for taxonomy_entry_point in sorted(taxonomies_referenced):
             logger.info(f"Archiving {taxonomy_entry_point}.")
 
             # Use Arelle to parse taxonomy

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -48,6 +48,11 @@ def parse_main(args=None):
         help="Initialize new deposition by preserving a DOI",
     )
     parser.add_argument(
+        "--clobber-unchanged",
+        action="store_true",
+        help="Delete draft deposition if unchanged.",
+    )
+    parser.add_argument(
         "--summary-file",
         type=Path,
         help="Generate a JSON archive run summary",

--- a/src/pudl_archiver/orchestrator.py
+++ b/src/pudl_archiver/orchestrator.py
@@ -49,6 +49,9 @@ async def orchestrate_run(
         draft.get_deposition_link(),
     )
     published = await draft.publish_if_valid(
-        summary, datapackage_updated, run_settings.auto_publish
+        summary,
+        datapackage_updated,
+        run_settings.clobber_unchanged,
+        run_settings.auto_publish,
     )
     return summary, published

--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -26,7 +26,7 @@ eia930:
   production_doi: 10.5281/zenodo.10840077
   sandbox_doi: 10.5072/zenodo.38409
 eiaaeo:
-  production_doi: 10.5281/zenodo.10838487
+  production_doi: 10.5281/zenodo.10838488
   sandbox_doi: 10.5072/zenodo.37746
 eia_bulk_elec:
   production_doi: 10.5281/zenodo.7067366

--- a/src/pudl_archiver/utils.py
+++ b/src/pudl_archiver/utils.py
@@ -127,6 +127,7 @@ class RunSettings(BaseModel):
     only_years: list[int] | None = []
     summary_file: Path | None = None
     download_dir: str | None = None
+    clobber_unchanged: bool = False
     auto_publish: bool = False
     refresh_metadata: bool = False
     resume_run: bool = False


### PR DESCRIPTION
# Overview

First part of changes for #418.

What did you change in this PR?
- Fixes AEO archiver due to return of delete DOI error (see #412, #398).
- Sorts FERC taxonomies to try and avoid changes in sorting marked as partition updates
- Returns delete_deposition method and adds it as default to small runs of the archiver. Leave the draft for CEMS and other future big runner archives, as it's a long and slow run. Add this method to the integration tests.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run an archive with no changes and with/without `--clobber-unchanged` (e.g. `epacamd_eia`). Should delete a draft when clobbering, and should leave a draft when not clobbering.

# To-do list

```[tasklist]
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
