### PR TITLE
Fix erroneous FERC XBRL updates

### DIFF
--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -360,7 +360,7 @@ async def archive_year(
         # Save snapshot of RSS feed
         with archive.open("rssfeed", "w") as f:
             logger.info("Writing rss feed metadata to archive.")
-            f.write(json.dumps(metadata, default=str).encode("utf-8"))
+            f.write(json.dumps(sorted(metadata), default=str, indent=2).encode("utf-8"))
 
     logger.info(f"Finished scraping ferc{form_number}-{year}.")
 

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -184,6 +184,12 @@ def _process_partition_diffs(
         baseline_val = baseline_partitions.get(key)
         new_val = new_partitions.get(key)
 
+        # Sort partitions if list or set
+        if isinstance(baseline_val, list | set):
+            baseline_val = sorted(baseline_val)
+        if isinstance(new_val, list | set):
+            new_val = sorted(new_val)
+
         match baseline_val, new_val:
             case [None, created_part_val]:
                 partition_diffs.append(

--- a/tests/unit/archive_validate_test.py
+++ b/tests/unit/archive_validate_test.py
@@ -57,6 +57,23 @@ logger = logging.getLogger(f"catalystcoop.{__name__}")
                 )
             ],
         ),
+        (
+            {"part0": ["val0", "val1"]},
+            {"part0": ["val1", "val0"]},
+            [],
+        ),
+        (
+            {"part0": ["val0", "val1"]},
+            {"part0": ["val1", "val0", "val2"]},
+            [
+                validate.PartitionDiff(
+                    key="part0",
+                    value=sorted(["val1", "val0", "val2"]),
+                    previous_value=["val0", "val1"],
+                    diff_type="UPDATE",
+                )
+            ],
+        ),
     ],
 )
 def test_process_partition_diffs(baseline_partitions, new_partitions, diffs):

--- a/tests/unit/ferc_archiver_test.py
+++ b/tests/unit/ferc_archiver_test.py
@@ -206,4 +206,7 @@ async def test_archive_year_metadata(tmpdir):
         zipfile.ZipFile(tmpdir / "ferc1-xbrl-2021.zip", mode="r") as archive,
         archive.open("rssfeed") as f,
     ):
-        assert json.dumps(expected_metadata, default=str).encode() == f.read()
+        assert (
+            json.dumps(sorted(expected_metadata), default=str, indent=2).encode()
+            == f.read()
+        )


### PR DESCRIPTION
# Overview

Closes #399.

### What problem does this address?
FERC XBRL resources have been marked as changed even when there don't appear to be actual changes. There seem to have been two primary causes of these changes:

1. XBRL archives have a partition key called `taxonomies_referenced` which lists any taxonomy referenced by filings in a year of data. These have been marked as changed when only the order of the list has actually changed.
2. XBRL archives contain an rssfeed metadata json file which has also been changed due to the ordering of filings in the json.

### What did you change in this PR?
This PR addresses both of these issues:
1. When comparing partition key value pairs, sort any values that are of type `list`
2. Sort keys in metadata json before writing to zipfile

# Testing
Problem `1.` is easy to test by creating a new archive and looking at the summary to see that there are no longer partition key changes. I also added a unit test to verify the behavior with list partition values.

Problem `2.` is harder to test, however. I manually verified that sorting the rssfeed metadata does lead to these files having the same hash, but because they are bundled in zipfiles it's hard to say conclusively that there are no other differences in the zipfiles that could be contributing to the erroneous changes. The easiest/most thorough way to check this would be to publish an archive, then rerun the archiver and see if it's still detecting changes.

To get more insight into the problem, I considered modifying the change detection to actually look inside zipfiles and produce file-by-file change summaries. However, given the current archiver architecture this is very difficult because we don't actually have the zipfiles locally when looking for changes. I do think this would be very useful functionality, but would require somewhat significant reworking.