### PR TITLE
Archive `gridpathratoolkit` data from GCS

### DIFF
--- a/src/pudl_archiver/archivers/gridpathratoolkit.py
+++ b/src/pudl_archiver/archivers/gridpathratoolkit.py
@@ -1,0 +1,57 @@
+"""Archive GridPath RA toolkit renewable generation data.
+
+This dataset was produced by Moment Energy Insights (now Sylvan Energy Analytics).
+It is archived from files stored in the private sources.catalyst.coop bucket.
+"""
+
+import logging
+from pathlib import Path
+
+from google.cloud import storage
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+logger = logging.getLogger(f"catalystcoop.{__name__}")
+
+
+class GridPathRAToolkitArchiver(AbstractDatasetArchiver):
+    """GridPath RA Toolkit renewable generation profiles archiver."""
+
+    name = "gridpathratoolkit"
+    bucket_name = "sources.catalyst.coop"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download VCE renewable generation resources."""
+        bucket = storage.Client().get_bucket(self.bucket_name)
+        blobs = bucket.list_blobs(prefix=f"{self.name}/")  # Get all blobs in folder
+
+        for blob in blobs:
+            # Skip the folder, which appears in this list
+            if not blob.name.endswith("/"):
+                yield self.get_gcs_resource(blob)
+
+    async def get_gcs_resource(self, blob: storage.Blob) -> tuple[Path, dict]:
+        """Download VCE renewable generation profile files from GCS.
+
+        There are three types of files: a documentation PDF, a single CSV and a series
+        of zipped annual files that are named vceregen_{year}.zip.
+        """
+        # Remove folder name (identical to dataset name) and set download path
+        file_name = blob.name.replace(f"{self.name}/", "")
+        path_to_file = self.download_directory / file_name
+        # Download blob to local file
+        logger.info(f"Downloading {blob.name} to {path_to_file}")
+        blob.download_to_filename(path_to_file)
+
+        # The partition should be the filename without the filetype extension.
+        # E.g., solar_capacity_aggregations.csv has part: solar_capacity_aggregations
+
+        part = file_name.split(".")[0]  # Remove .csv/.zip extension
+        return ResourceInfo(
+            local_path=path_to_file,
+            partitions={"part": part},
+        )

--- a/src/pudl_archiver/archivers/vceregen.py
+++ b/src/pudl_archiver/archivers/vceregen.py
@@ -73,8 +73,8 @@ class VCEReGenArchiver(AbstractDatasetArchiver):
                 partitions={"fips": True},
             )
 
-        # Handle documentation
-        if file_name.endswith(".pdf"):
+        # Handle documentation and README
+        if file_name.endswith(".pdf") or file_name.endswith(".md"):
             return ResourceInfo(local_path=path_to_file, partitions={})
 
         raise AssertionError(

--- a/src/pudl_archiver/archivers/vceregen.py
+++ b/src/pudl_archiver/archivers/vceregen.py
@@ -1,0 +1,82 @@
+"""Archive VCE renewable generation data.
+
+This dataset was produced by Vibrant Clean Energy, and is licensed to the public under
+the Creative Commons Attribution 4.0 International license (CC-BY-4.0). It is archived
+from files stored in the private sources.catalyst.coop bucket.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+from google.cloud import storage
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+logger = logging.getLogger(f"catalystcoop.{__name__}")
+
+
+class VCEReGenArchiver(AbstractDatasetArchiver):
+    """VCE Renewable Generation Profiles archiver."""
+
+    name = "vceregen"
+    bucket_name = "sources.catalyst.coop"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download VCE renewable generation resources."""
+        bucket = storage.Client().get_bucket(self.bucket_name)
+        blobs = bucket.list_blobs(prefix=f"{self.name}/")  # Get all blobs in folder
+
+        for blob in blobs:
+            # Skip the folder, which appears in this list
+            if not blob.name.endswith("/"):
+                yield self.get_gcs_resource(blob)
+
+    async def get_gcs_resource(self, blob: storage.Blob) -> tuple[Path, dict]:
+        """Download VCE renewable generation profile files from GCS.
+
+        There are three types of files: a documentation PDF, a single CSV and a series
+        of zipped annual files that are named vceregen_{year}.zip.
+        """
+        # Remove folder name (identical to dataset name) and set download path
+        file_name = blob.name.replace(f"{self.name}/", "")
+        path_to_file = self.download_directory / file_name
+        # Download blob to local file
+        logger.info(f"Downloading {blob.name} to {path_to_file}")
+        blob.download_to_filename(path_to_file)
+
+        # Set up partitions:
+        # vceregen-ra-county-lat-long-fips.csv should have partition fips: true
+        # vceregen-YYYY.zip should have partition year: YYYY
+        # The documentation file should have no partitions, as we don't ETL it.
+
+        # Handle annual zip files
+        annual_zip_pattern = re.compile(
+            rf"^{self.name}-(\d{{4}}).zip"
+        )  # Double escape the {4}
+        annual_match = annual_zip_pattern.match(file_name)
+        if annual_match:
+            year = int(annual_match.group(1))
+            return ResourceInfo(
+                local_path=path_to_file,
+                partitions={"year": year},
+            )
+
+        # Handle single lat/lon/FIPS CSV
+        if file_name == "vceregen-ra-county-lat-long-fips.csv":
+            return ResourceInfo(
+                local_path=path_to_file,
+                partitions={"fips": True},
+            )
+
+        # Handle documentation
+        if file_name.endswith(".pdf"):
+            return ResourceInfo(local_path=path_to_file, partitions={})
+
+        raise AssertionError(
+            f"New file {file_name} detected. Update the archiver to process it."
+        )

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -19,6 +19,8 @@ MEDIA_TYPES: dict[str, str] = {
     "csv": "text/csv",
     "txt": "text/csv",
     "parquet": "application/vnd.apache.parquet",
+    "pdf": "application/pdf",
+    "md": "text/markdown",
 }
 
 


### PR DESCRIPTION
# Overview

Closes https://github.com/catalyst-cooperative/pudl/issues/3895

What problem does this address?
Archives `gridpathratoolkit` data by uploading the original files given to us by Moment Energy Insights to a private `sources.catalyst.coop` bucket, and then directing the archiver to grab the data from there. This way, we can update the data in the GCS bucket and the archiver will automatically grab the new files and update the `datapackage.json` file.

What did you change in this PR?
Mimic the archiver in #438, but for the GridPath data.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `pudl_archiver --datasets vceregen --sandbox --initialize`

# To-do list

```[tasklist]
- [ ] Verify sandbox archive looks as expected and publish production archive
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
