### PR TITLE
Fix slack GitHub action

### DIFF
--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -99,6 +99,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
           payload: |
+            text: "PUDL data archive run complete."
             blocks: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
             channel: "C03FHB9N0PQ"
 

--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -96,10 +96,11 @@ jobs:
       - name: Post update to pudl-deployment
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: "C03FHB9N0PQ"
-          payload: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          payload: |
+            text: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+            channel: "C03FHB9N0PQ"
 
   make-github-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -100,7 +100,7 @@ jobs:
           token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
           payload: |
             text: "PUDL data archive run complete."
-            attachments: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+            blocks: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
             channel: "C03FHB9N0PQ"
 
   make-github-issue:

--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -99,7 +99,6 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
           payload: |
-            text: "PUDL data archive run complete."
             blocks: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
             channel: "C03FHB9N0PQ"
 

--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -99,7 +99,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
           payload: |
-            text: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+            attachments: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
             channel: "C03FHB9N0PQ"
 
   make-github-issue:

--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -99,6 +99,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
           payload: |
+            text: "PUDL data archive run complete."
             attachments: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
             channel: "C03FHB9N0PQ"
 

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -107,7 +107,8 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
           payload: |
-            text: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+            text: "PUDL data archive run complete."
+            blocks: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
             channel: "C03FHB9N0PQ"
 
   make-github-issue:

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -104,10 +104,11 @@ jobs:
       - name: Post update to pudl-deployment
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: "C03FHB9N0PQ"
-          payload: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          payload: |
+            text: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+            channel: "C03FHB9N0PQ"
 
   make-github-issue:
     if: ${{ always() && (github.event_name == 'schedule' || inputs.create_github_issue == true) }}

--- a/scripts/make_slack_notification_message.py
+++ b/scripts/make_slack_notification_message.py
@@ -123,14 +123,10 @@ def main(summary_files: list[Path]) -> None:
     print(
         json.dumps(
             {
-                "attachments": [
-                    {
-                        "blocks": [header_block("Archiver Run Outcomes")]
-                        + failed_blocks
-                        + changed_blocks
-                        + unchanged_blocks,
-                    }
-                ]
+                [header_block("Archiver Run Outcomes")]
+                + failed_blocks
+                + changed_blocks
+                + unchanged_blocks,
             },
             indent=2,
         )

--- a/scripts/make_slack_notification_message.py
+++ b/scripts/make_slack_notification_message.py
@@ -122,12 +122,10 @@ def main(summary_files: list[Path]) -> None:
 
     print(
         json.dumps(
-            {
-                [header_block("Archiver Run Outcomes")]
-                + failed_blocks
-                + changed_blocks
-                + unchanged_blocks,
-            },
+            [header_block("Archiver Run Outcomes")]
+            + failed_blocks
+            + changed_blocks
+            + unchanged_blocks,
             indent=2,
         )
     )


### PR DESCRIPTION
# Overview

Update our usage of `slack-github-action` to be compatible with the new v2.0 of that action.

# Testing

The same action failed in the main PUDL repo and this fix worked there. Just updating the syntax here. Have not actually tested (but the old way would definitely fail).