### PR TITLE
If no epacems_api_key, return `None` instead of throwing an exception

### DIFF
--- a/src/pudl_archiver/archivers/epacems.py
+++ b/src/pudl_archiver/archivers/epacems.py
@@ -61,7 +61,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
     allowed_file_rel_diff = 0.35  # Set higher tolerance than standard
 
     base_url = "https://api.epa.gov/easey/bulk-files/"
-    parameters = {"api_key": os.environ["EPACEMS_API_KEY"]}  # Set to API key
+    parameters = {"api_key": os.environ.get("EPACEMS_API_KEY")}  # Set to API key
 
     def __filter_for_complete_metadata(
         self, files_responses: list[dict]


### PR DESCRIPTION
# Overview

What problem does this address?
Right now if there's no `EPACEMS_API_KEY` set in the environment, an error is thrown whether or not a user is actually archiving EPA CEMS data. This came up in another repository importing the `pudl-archiver` code to run an archiver.

What did you change in this PR?
Switched from using `os.environ['EPACEMS_API_KEY']` which raises an error if this doesn't exist, to `os.environ.get("EPACEMS_API_KEY")` which will return `None`. This will still fail if the EPA CEMS API key is being called in the archiver, but will allow people to run other archivers without making a fake EPA CEMS API key environment variable.

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
