### PR TITLE
Make census fips codes archiver

### DIFF
--- a/src/pudl_archiver/archivers/censusfips.py
+++ b/src/pudl_archiver/archivers/censusfips.py
@@ -26,22 +26,24 @@ class CensusFipsArchiver(AbstractDatasetArchiver):
             if not matches:
                 continue
             year = int(matches.group(1))
-            # don't go peep into the 1990-2000/ dir which just includes a txt file
-            if self.valid_year(year) and year != 2000:
+            if self.valid_year(year):
                 yield self.get_year_resource(year)
 
     async def get_year_resource(self, year: int) -> tuple[Path, dict]:
-        """Download excel file."""
+        """Download excel or txt file."""
         # before 2017, the files are xls. after that its xlsx
-        link_url = f"{BASE_URL}/{year}"
-        link_pattern = re.compile(rf"all-geocodes-v{year}.(xlsx|xls)")
-        file_names = await self.get_hyperlinks(link_url, link_pattern)
-        if len(file_names) != 1:
-            raise AssertionError(
-                f"We expected exactly one link for {year}, but we found: {file_names}"
-            )
-        file_name = file_names.pop()
+        if year != 2000:
+            link_url = f"{BASE_URL}/{year}"
+            link_pattern = re.compile(rf"all-geocodes-v{year}.(xlsx|xls)")
+            file_names = await self.get_hyperlinks(link_url, link_pattern)
+            if len(file_names) != 1:
+                raise AssertionError(
+                    f"We expected exactly one link for {year}, but we found: {file_names}"
+                )
+            file_name = file_names.pop()
+        elif year == 2000:
+            link_url = f"{BASE_URL}/1990-2000"
+            file_name = "90s-fips.txt"
         download_path = self.download_directory / file_name
         await self.download_file(f"{link_url}/{file_name}", download_path)
-
         return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/censusfips.py
+++ b/src/pudl_archiver/archivers/censusfips.py
@@ -9,7 +9,7 @@ from pudl_archiver.archivers.classes import (
     ResourceInfo,
 )
 
-BASE_URL = "https://www2.census.gov/programs-surveys/popest/geographies/"
+BASE_URL = "https://www2.census.gov/programs-surveys/popest/geographies"
 
 
 class CensusFipsArchiver(AbstractDatasetArchiver):
@@ -26,14 +26,15 @@ class CensusFipsArchiver(AbstractDatasetArchiver):
             if not matches:
                 continue
             year = int(matches.group(1))
-            if self.valid_year(year):
+            # don't go peep into the 1990-2000/ dir which just includes a txt file
+            if self.valid_year(year) and year != 2000:
                 yield self.get_year_resource(year)
 
     async def get_year_resource(self, year: int) -> tuple[Path, dict]:
         """Download excel file."""
         # before 2017, the files are xls. after that its xlsx
         file_extension = "xlsx" if year >= 2017 else "xls"
-        file_name = f"state-geocodes-v{year}.{file_extension}"
+        file_name = f"all-geocodes-v{year}.{file_extension}"
         url = f"{BASE_URL}/{year}/{file_name}"
         download_path = self.download_directory / file_name
         await self.download_file(url, download_path)

--- a/src/pudl_archiver/archivers/censusfips.py
+++ b/src/pudl_archiver/archivers/censusfips.py
@@ -1,0 +1,41 @@
+"""Download US Census FIPS Codes."""
+
+import re
+from pathlib import Path
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+BASE_URL = "https://www2.census.gov/programs-surveys/popest/geographies/"
+
+
+class CensusFipsArchiver(AbstractDatasetArchiver):
+    """Census FIPS Codes archiver."""
+
+    name = "censusfips"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download Census FIPS Codes resources."""
+        # the BASE_URL page has a bunch of links with YEAR/ at the end
+        link_pattern = re.compile(r"(\d{4})/$")
+        for link in await self.get_hyperlinks(BASE_URL, link_pattern):
+            matches = link_pattern.search(link)
+            if not matches:
+                continue
+            year = int(matches.group(1))
+            if self.valid_year(year):
+                yield self.get_year_resource(year)
+
+    async def get_year_resource(self, year: int) -> tuple[Path, dict]:
+        """Download excel file."""
+        # before 2017, the files are xls. after that its xlsx
+        file_extension = "xlsx" if year >= 2017 else "xls"
+        file_name = f"state-geocodes-v{year}.{file_extension}"
+        url = f"{BASE_URL}/{year}/{file_name}"
+        download_path = self.download_directory / file_name
+        await self.download_file(url, download_path)
+
+        return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/censuspep.py
+++ b/src/pudl_archiver/archivers/censuspep.py
@@ -47,6 +47,7 @@ class CensusPepArchiver(AbstractDatasetArchiver):
         elif year == 2000:
             link_url = f"{BASE_URL}/1990-2000"
             file_name = "90s-fips.txt"
-        download_path = self.download_directory / file_name
-        await self.download_file(f"{link_url}/{file_name}", download_path)
+        url = f"{link_url}/{file_name}"
+        download_path = self.download_directory / f"{self.name}_{year}.zip"
+        await self.download_and_zip_file(url, file_name, download_path)
         return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/censuspep.py
+++ b/src/pudl_archiver/archivers/censuspep.py
@@ -1,4 +1,4 @@
-"""Download US Census FIPS Codes."""
+"""Download US Census Federal Information Processing Standards (FIPS) codes from Population Estimates Program (PEP)."""
 
 import re
 from pathlib import Path
@@ -12,13 +12,13 @@ from pudl_archiver.archivers.classes import (
 BASE_URL = "https://www2.census.gov/programs-surveys/popest/geographies"
 
 
-class CensusFipsArchiver(AbstractDatasetArchiver):
-    """Census FIPS Codes archiver."""
+class CensusPepArchiver(AbstractDatasetArchiver):
+    """Census PEP FIPS Codes archiver."""
 
-    name = "censusfips"
+    name = "censuspep"
 
     async def get_resources(self) -> ArchiveAwaitable:
-        """Download Census FIPS Codes resources."""
+        """Download Census PEP FIPS Codes resources."""
         # the BASE_URL page has a bunch of links with YEAR/ at the end
         link_pattern = re.compile(r"(\d{4})/$")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
@@ -31,9 +31,12 @@ class CensusFipsArchiver(AbstractDatasetArchiver):
 
     async def get_year_resource(self, year: int) -> tuple[Path, dict]:
         """Download excel or txt file."""
-        # before 2017, the files are xls. after that its xlsx
+        # every directory besides the 1990-2000 dir has excel files
+        # that we have to sift through to find the correct file.
+        # the oldest data (1990-2000) dir includes just one txt file.
         if year != 2000:
             link_url = f"{BASE_URL}/{year}"
+            # before 2017, the files are xls. after that its xlsx
             link_pattern = re.compile(rf"all-geocodes-v{year}.(xlsx|xls)")
             file_names = await self.get_hyperlinks(link_url, link_pattern)
             if len(file_names) != 1:

--- a/src/pudl_archiver/archivers/censuspep.py
+++ b/src/pudl_archiver/archivers/censuspep.py
@@ -48,6 +48,6 @@ class CensusPepArchiver(AbstractDatasetArchiver):
             link_url = f"{BASE_URL}/1990-2000"
             file_name = "90s-fips.txt"
         url = f"{link_url}/{file_name}"
-        download_path = self.download_directory / f"{self.name}_{year}.zip"
+        download_path = self.download_directory / f"{self.name}-{year}.zip"
         await self.download_and_zip_file(url, file_name, download_path)
         return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -144,7 +144,7 @@ class AbstractDatasetArchiver(ABC):
 
         Args:
             url: URL of zipfile.
-            file_path: Local path to write file to disk or bytes object to save file in memory.
+            zip_path: Local path to write file to disk or bytes object to save file in memory.
             retries: Number of times to attempt to download a zipfile.
             kwargs: Key word args to pass to request.
         """

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -138,61 +138,52 @@ class AbstractDatasetArchiver(ABC):
         ...
 
     async def download_zipfile(
-        self, url: str, file: Path | io.BytesIO, retries: int = 5, **kwargs
+        self, url: str, zip_path: Path | io.BytesIO, retries: int = 5, **kwargs
     ):
         """Attempt to download a zipfile and retry if zipfile is invalid.
 
         Args:
             url: URL of zipfile.
-            file: Local path to write file to disk or bytes object to save file in memory.
+            file_path: Local path to write file to disk or bytes object to save file in memory.
             retries: Number of times to attempt to download a zipfile.
             kwargs: Key word args to pass to request.
         """
         for _ in range(0, retries):
-            await self.download_file(url, file, **kwargs)
+            await self.download_file(url, zip_path, **kwargs)
 
-            if zipfile.is_zipfile(file):
+            if zipfile.is_zipfile(zip_path):
                 return
 
         # If it makes it here that means it couldn't download a valid zipfile
         raise RuntimeError(f"Failed to download valid zipfile from {url}")
 
-    async def download_file(
-        self,
-        url: str,
-        file: Path | io.BytesIO,
-        **kwargs,
-    ):
+    async def download_file(self, url: str, file_path: Path | io.BytesIO, **kwargs):
         """Download a file using async session manager.
 
         Args:
             url: URL to file to download.
-            file: Local path to write file to disk or bytes object to save file in memory.
-            kwargs: Key word args to pass to request.
+            file_path: Local path to write file to disk or bytes object to save file in memory.
+            kwargs: Key word args to pass to retry_async.
         """
-        await retry_async(_download_file, [self.session, url, file], kwargs)
+        await retry_async(_download_file, [self.session, url, file_path], kwargs)
 
     async def download_and_zip_file(
-        self,
-        url: str,
-        filename: str,
-        archive_path: Path,
-        **kwargs,
+        self, url: str, filename: str, zip_path: Path, **kwargs
     ):
         """Download and zip a file using async session manager.
 
         Args:
             url: URL to file to download.
             filename: name of file to be zipped
-            archive_path: Local path to write file to disk.
-            kwargs: Key word args to pass to request.
+            zip_path: Local path to write file to disk.
+            kwargs: Key word args to pass to retry_async.
         """
         response = await retry_async(self.session.get, args=[url], kwargs=kwargs)
         response_bytes = await retry_async(response.read)
 
         # Write to zipfile
         with zipfile.ZipFile(
-            archive_path,
+            zip_path,
             "w",
             compression=zipfile.ZIP_DEFLATED,
         ) as archive:
@@ -200,20 +191,22 @@ class AbstractDatasetArchiver(ABC):
                 archive=archive, filename=filename, data=response_bytes
             )
 
-    def add_to_archive(self, target_archive: Path, name: str, blob: typing.BinaryIO):
+    def add_to_archive(self, zip_path: Path, filename: str, blob: typing.BinaryIO):
         """Add a file to a ZIP archive.
 
         Args:
-            target_archive: path to target archive.
-            name: name of the file *within* the archive.
+            zip_path: path to target archive.
+            filename: name of the file *within* the archive.
             blob: the content you'd like to write to the archive.
         """
         with zipfile.ZipFile(
-            target_archive,
+            zip_path,
             "a",
             compression=zipfile.ZIP_DEFLATED,
         ) as archive:
-            add_to_archive_stable_hash(archive=archive, filename=name, data=blob.read())
+            add_to_archive_stable_hash(
+                archive=archive, filename=filename, data=blob.read()
+            )
 
     async def get_json(self, url: str, **kwargs) -> dict[str, str]:
         """Get a JSON and return it as a dictionary."""

--- a/src/pudl_archiver/archivers/eia/eia860m.py
+++ b/src/pudl_archiver/archivers/eia/eia860m.py
@@ -43,25 +43,25 @@ class Eia860MArchiver(AbstractDatasetArchiver):
         self, year: int, month_links: dict[int, str]
     ) -> ResourceInfo:
         """Download xlsx file."""
-        archive_path = self.download_directory / f"eia860m-{year}.zip"
+        zip_path = self.download_directory / f"eia860m-{year}.zip"
         data_paths_in_archive = set()
         for month, link in sorted(month_links.items()):
             url = f"https://eia.gov/{link}"
-            name = f"eia860m-{year}-{month:02}.xlsx"
-            download_path = self.download_directory / name
+            filename = f"eia860m-{year}-{month:02}.xlsx"
+            download_path = self.download_directory / filename
             await self.download_file(url, download_path)
             self.add_to_archive(
-                target_archive=archive_path,
-                name=name,
+                zip_path=zip_path,
+                filename=filename,
                 blob=download_path.open("rb"),
             )
-            data_paths_in_archive.add(name)
+            data_paths_in_archive.add(filename)
             # Don't want to leave multiple giant CSVs on disk, so delete
             # immediately after they're safely stored in the ZIP
             download_path.unlink()
 
         return ResourceInfo(
-            local_path=archive_path,
+            local_path=zip_path,
             partitions={
                 "year_month": sorted([f"{year}-{month:02}" for month in month_links])
             },

--- a/src/pudl_archiver/archivers/epacems.py
+++ b/src/pudl_archiver/archivers/epacems.py
@@ -113,7 +113,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
             year: the year we're downloading data for
             files: the files we've associated with this year.
         """
-        archive_path = self.download_directory / f"epacems-{year}.zip"
+        zip_path = self.download_directory / f"epacems-{year}.zip"
         data_paths_in_archive = set()
         for file in files:
             url = self.base_url + file.s3_path
@@ -124,10 +124,10 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
 
             filename = f"epacems-{year}q{quarter}.csv"
             file_path = self.download_directory / filename
-            await self.download_file(url=url, file=file_path)
+            await self.download_file(url=url, file_path=file_path)
             self.add_to_archive(
-                target_archive=archive_path,
-                name=filename,
+                zip_path=zip_path,
+                filename=filename,
                 blob=file_path.open("rb"),
             )
             data_paths_in_archive.add(filename)
@@ -136,7 +136,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
             file_path.unlink()
 
         return ResourceInfo(
-            local_path=archive_path,
+            local_path=zip_path,
             partitions={
                 "year_quarter": sorted(
                     [f"{year}q{file.metadata.quarter}" for file in files]

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -27,7 +27,7 @@ def parse_main(args=None):
     parser.add_argument(
         "--only-years",
         nargs="*",
-        help="Years to download data for. Supported datasets: censusdp1tract, censusfips, "
+        help="Years to download data for. Supported datasets: censusdp1tract, censuspep, "
         "eia176, eia191, eia757a, eia860, eia860m, eia861, eia923, eia930, eia_bulk_elec, "
         "eiaaeo, eiawater, epacamd_eia, epacems, ferc1, ferc2, ferc6, ferc60, ferc714, "
         "mshamines, nrelatb, phmsagas",

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -27,8 +27,8 @@ def parse_main(args=None):
     parser.add_argument(
         "--only-years",
         nargs="*",
-        help="Years to download data for. Supported datasets: censusdp1tract, eia176, "
-        "eia191, eia757a, eia860, eia860m, eia861, eia923, eia930, eia_bulk_elec, "
+        help="Years to download data for. Supported datasets: censusdp1tract, censusfips, "
+        "eia176, eia191, eia757a, eia860, eia860m, eia861, eia923, eia930, eia_bulk_elec, "
         "eiaaeo, eiawater, epacamd_eia, epacems, ferc1, ferc2, ferc6, ferc60, ferc714, "
         "mshamines, nrelatb, phmsagas",
         type=int,

--- a/src/pudl_archiver/frictionless.py
+++ b/src/pudl_archiver/frictionless.py
@@ -16,6 +16,7 @@ from pudl_archiver.utils import Url
 MEDIA_TYPES: dict[str, str] = {
     "zip": "application/zip",
     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "xls": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "csv": "text/csv",
     "txt": "text/csv",
     "parquet": "application/vnd.apache.parquet",

--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -1,6 +1,9 @@
 censusdp1tract:
   production_doi: 10.5281/zenodo.4127048
   sandbox_doi: 10.5072/zenodo.3138
+censuspep:
+  production_doi: 10.5281/zenodo.14624611
+  sandbox_doi: 10.5072/zenodo.151368
 eia176:
   production_doi: 10.5281/zenodo.7682357
   sandbox_doi: 10.5072/zenodo.3158


### PR DESCRIPTION
# Overview

working on https://github.com/catalyst-cooperative/pudl/issues/3884

What problem does this address?
- this adds an archiver which grabs that county level fips codes from the census

What did you change in this PR?
- i added an archiver module. I used the template in the readme and edited it mostly using patterns from the NREL ATB archiver
- I was surprised to have to add an `xls` media type. this was only required for the older files but i'm surprised we've never had to archive `xls` files. Did I miss something here?
- I had to do a semi-janky add of the [1990-2000/](https://www2.census.gov/programs-surveys/popest/geographies/1990-2000/).. txt file. 
- (i also added census metadata in pudl - i will link make that pr and link to it here)

# Testing

How did you make sure this worked? How can a reviewer verify this?

I ran `pudl_archiver --datasets censusfips --initialize --summary-file censusfips-summary.json`

to make a draft/sandbox archives here:
- https://zenodo.org/uploads/14648211
- https://sandbox.zenodo.org/records/151369

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
