### PR TITLE
Bump gdal version to match main PUDL repo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,6 @@ dependencies:
   # GDAL is a transitive dependency whose binaries must match those installed by the
   # pudl-dev conda environment, so we also install it with conda here.
   # TODO: once we break the archiver repo's dependency on pudl we should remove this.
-  - gdal==3.9.3 # pinned to ensure it matches pudl-dev environment exactly.
+  - gdal==3.10.0 # pinned to ensure it matches pudl-dev environment exactly.
   - pip:
       - --editable ./[dev,docs,tests]


### PR DESCRIPTION
# Overview

All this does is bump the version of the binary `gdal` dependency to match what we have in the main PUDL repo, since they need to remain synchronized.

This PR should not be merged until https://github.com/catalyst-cooperative/pudl/pull/4010 has merged.
