### PR TITLE
Add a weekly archiver run on Mondays that doesn't create a Github issue

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -15,6 +15,7 @@ on:
         required: true
         type: boolean
   schedule:
+    - cron: "21 8 1 * *" # 8:21 AM UTC, first of every month
     - cron: "21 8 * * 1" # 8:21 AM UTC, every Monday
 
 jobs:
@@ -112,7 +113,10 @@ jobs:
             channel: "C03FHB9N0PQ"
 
   make-github-issue:
-    if: ${{ always() && (github.event_name == 'schedule' || inputs.create_github_issue == true) }}
+    # If event is a scheduled run on the first of the month or a workflow run where an issue
+    # is requested, create an issue. Do not create issues for weekly Monday runs to avoid
+    # having to manually close them for now, given the goal of publishing archives monthly.
+    if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '21 8 1 * *') || inputs.create_github_issue == true) }}
     runs-on: ubuntu-latest
     needs:
       - archive-run

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: boolean
   schedule:
-    - cron: "21 8 1 * *" # 8:21 AM UTC, first of every month
+    - cron: "21 8 * * 1" # 8:21 AM UTC, every Monday
 
 jobs:
   archive-run:


### PR DESCRIPTION
# Overview

What problem does this address?
We sometimes get archivers published shortly after our monthly archive run, and we may want a more granular update on changes in any data archive. However, we have budget for a monthly update of our archivers, so we don't necessarily want to be publishing all of our archives each week as changes occur.

What did you change in this PR?
- Add a second cron schedule that runs all our archivers every Monday at 8:21 AM UTC
- This schedule _does not_ create a new Github archive - it's purely for informational purposes, and we can decide to create a Github issue / publish these archives on an as-needed basis, rather than having to close a Github issue each week.

# Testing

How did you make sure this worked? How can a reviewer verify this?
This will require merging to main to verify that it works as cron jobs only run on `main`, but you can test a manual workflow run on this branch to make sure it hasn't completely broken the GHA.

# To-do list

```[tasklist]
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
