### PR TITLE
generalize hyperlink extractor

### DIFF
--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -49,15 +49,31 @@ class _HyperlinkExtractor(HTMLParser):
 
     def __init__(self):
         """Construct parser."""
-        self.hyperlinks = set()
+        self.hyperlinks = dict()
+        self.current_hyperlink = None
         super().__init__()
 
     def handle_starttag(self, tag, attrs):
         """Filter hyperlink tags and return href attribute."""
-        if tag == "a":
-            for attr, val in attrs:
-                if attr == "href":
-                    self.hyperlinks.add(val)
+        url_attrs = ["href", "src", "action", "data-url", "poster"]
+
+        for attr, val in attrs:
+            if attr in url_attrs:
+                self.current_hyperlink = val
+                if self.current_hyperlink not in self.hyperlinks:
+                    # By default, set the name identical to the hyperlink
+                    self.hyperlinks[self.current_hyperlink] = self.current_hyperlink
+                break
+
+    def handle_data(self, data):
+        """Capture text content and associate it with the current URL."""
+        if self.current_hyperlink and data.strip():
+            # If data is present, replace the hyperlink name
+            self.hyperlinks[self.current_hyperlink] = data.strip()
+
+    def handle_endtag(self, tag):
+        """Reset the current URL after processing the content of the tag."""
+        self.current_hyperlink = None
 
 
 async def _download_file(
@@ -275,8 +291,13 @@ class AbstractDatasetArchiver(ABC):
 
         # Filter to those that match filter_pattern
         hyperlinks = parser.hyperlinks
+
         if filter_pattern:
-            hyperlinks = {link for link in hyperlinks if filter_pattern.search(link)}
+            hyperlinks = {
+                link: name
+                for link, name in hyperlinks.items()
+                if filter_pattern.search(name)
+            }
 
         # Warn if no links are found
         if not hyperlinks:

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -296,7 +296,7 @@ class AbstractDatasetArchiver(ABC):
             hyperlinks = {
                 link: name
                 for link, name in hyperlinks.items()
-                if filter_pattern.search(name)
+                if filter_pattern.search(name) or filter_pattern.search(link)
             }
 
         # Warn if no links are found

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -49,7 +49,7 @@ class _HyperlinkExtractor(HTMLParser):
 
     def __init__(self):
         """Construct parser."""
-        self.hyperlinks = dict()
+        self.hyperlinks = {}
         self.current_hyperlink = None
         super().__init__()
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #XXXX.

What problem does this address?
- Hyperlink extractor does not return URLs in tags other than `<a>` tags
- Hyperlink extractor also does not return information inside the tags, which could contain the actual filename, e.g. `<a href="...">filename.zip</a>`
- In the case of the new data archiver https://github.com/catalyst-cooperative/pudl-archiver/pull/539 the name would be needed for extracting properties such as dataset upload date.

What did you change in this PR?
- Hyperlink extractor returns all hyperlinks (based on some list of attributes rather than only the href attribute in the <a> tag)
- Return value is dict instead of set, with values {hyperlink: name} where name contains the text between tags, if present, and defaults to hyperlink itself.
- Check for name matches in both the name and the hyperlink instead of just the hyperlink

# Testing

WIP
Note that the change from datatype set -> dict should not be an issue downstream as long as the result of `get_hyperlinks` is looped over, since a simple for loop returns the keys, which are the hyperlinks, and ignores the values. This should be checked.
~Errors might occur if there is text between the tags but it lacks information that is present in the hyperlink, resulting in hyperlinks not being downloaded.~ solved by checking both name and link for pattern

# To-do list

```[tasklist]
- [ ] How to handle cases where the text between tags does not contain the filename (so we may want to default to the hyperlink for the name in that case)
- [ ] Use the name as the filename if downstream usecase does expect a valid filename, and the hyperlink does not contain the filename
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
