### PR TITLE
Archive USGS PV database

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       datasets:
         description: 'Comma-separated list of datasets to archive (e.g., "ferc2","ferc6").'
-        default: '"eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiawater","eia_bulk_elec","epacamd_eia","epacems","ferc1","ferc2","ferc6","ferc60","ferc714","gridpathratoolkit","mshamines","nrelatb","phmsagas","vcerare"'
+        default: '"eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiawater","eia_bulk_elec","epacamd_eia","epacems","ferc1","ferc2","ferc6","ferc60","ferc714","gridpathratoolkit","mshamines","nrelatb","phmsagas","usgsuspvdb","vcerare"'
         required: true
         type: string
       create_github_issue:
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         # Note that we can't pass global env variables to the matrix, so we manually reproduce the list of datasets here.
-        dataset: ${{ fromJSON(format('[{0}]', inputs.datasets || '"eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiawater","eia_bulk_elec","epacamd_eia","epacems","ferc1","ferc2","ferc6","ferc60","ferc714","gridpathratoolkit","mshamines","nrelatb","phmsagas","vcerare"' )) }}
+        dataset: ${{ fromJSON(format('[{0}]', inputs.datasets || '"eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiawater","eia_bulk_elec","epacamd_eia","epacems","ferc1","ferc2","ferc6","ferc60","ferc714","gridpathratoolkit","mshamines","nrelatb","phmsagas","usgsuspvdb","vcerare"' )) }}
       fail-fast: false
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.xml
 **/*~
 .hypothesis/*
 .vscode/*
+node_modules/*

--- a/src/pudl_archiver/archivers/usgsuspvdb.py
+++ b/src/pudl_archiver/archivers/usgsuspvdb.py
@@ -11,6 +11,7 @@ from pudl_archiver.archivers.classes import (
 
 class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
     """USGS USPVDB -- U.S. Large-Scale Solar Photovoltaic Database.
+
     This dataset is mainly static with versions that are issued as separate datasets. As of
     Jan 2025, there are 2 Child items (versions) viewable at
     https://www.sciencebase.gov/catalog/item/66707f69d34e89718fa3f82f (United States
@@ -32,9 +33,11 @@ class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
             yield self.get_crosswalk_zip(year)
 
     async def get_crosswalk_zip(self, year: int) -> tuple[Path, dict]:
-        """Download entire repo as a zipfile.
+        """Download entire dataset as a zipfile.
 
-        .
+        The `get` URLs are found on: 
+        * https://www.sciencebase.gov/catalog/item/6442d8a2d34ee8d4ade8e6db
+        * https://www.sciencebase.gov/catalog/item/6671c479d34e84915adb7536
         """
         crosswalk_urls = {
             2023: "https://www.sciencebase.gov/catalog/file/get/6442d8a2d34ee8d4ade8e6db",

--- a/src/pudl_archiver/archivers/usgsuspvdb.py
+++ b/src/pudl_archiver/archivers/usgsuspvdb.py
@@ -35,11 +35,11 @@ class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
     async def get_crosswalk_zip(self, year: int) -> tuple[Path, dict]:
         """Download entire repo as a zipfile.
 
-        F.
+        .
         """
         crosswalk_urls = {
-            2023: "https://www.sciencebase.gov/catalog/item/6442d8a2d34ee8d4ade8e6db",
-            2024: "https://www.sciencebase.gov/catalog/item/6671c479d34e84915adb7536",
+            2023: "https://www.sciencebase.gov/catalog/file/get/6442d8a2d34ee8d4ade8e6db",
+            2024: "https://www.sciencebase.gov/catalog/file/get/6671c479d34e84915adb7536",
         }
         download_path = self.download_directory / f"usgsuspvdb_{year}.zip"
         await self.download_zipfile(crosswalk_urls[year], download_path)

--- a/src/pudl_archiver/archivers/usgsuspvdb.py
+++ b/src/pudl_archiver/archivers/usgsuspvdb.py
@@ -1,5 +1,6 @@
 """Download USGS USPVDB -- U.S. Large-Scale Solar Photovoltaic Database."""
 
+import re
 from pathlib import Path
 
 from pudl_archiver.archivers.classes import (
@@ -7,6 +8,8 @@ from pudl_archiver.archivers.classes import (
     ArchiveAwaitable,
     ResourceInfo,
 )
+
+BASE_URL = "https://www.sciencebase.gov/catalog/items?parentId=66707f69d34e89718fa3f82f"
 
 
 class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
@@ -29,21 +32,36 @@ class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download the 2 version of the database released in different years."""
-        for year in [2023, 2024]:
-            yield self.get_crosswalk_zip(year)
+        # Get any link matching /item/alphanumeric and capture the alphanumeric part
+        link_pattern = re.compile(r"\/item\/(\w+)$")
+        for link in await self.get_hyperlinks(BASE_URL, link_pattern):
+            dataset_id = link_pattern.search(link).group(1)
+            yield self.get_crosswalk_zip(link, dataset_id)
 
-    async def get_crosswalk_zip(self, year: int) -> tuple[Path, dict]:
+    async def get_crosswalk_zip(self, link: str, dataset_id: str) -> tuple[Path, dict]:
         """Download entire dataset as a zipfile.
 
         The `get` URLs are found on:
         * https://www.sciencebase.gov/catalog/item/6442d8a2d34ee8d4ade8e6db
         * https://www.sciencebase.gov/catalog/item/6671c479d34e84915adb7536
+
+        The date on the file is the date of publication, while we want the date of the
+        partition to correspond to data availability. For simplicity, we map this manually
+        and alert ourselves when any new data is published.
         """
         crosswalk_urls = {
-            2023: "https://www.sciencebase.gov/catalog/file/get/6442d8a2d34ee8d4ade8e6db",
-            2024: "https://www.sciencebase.gov/catalog/file/get/6671c479d34e84915adb7536",
+            "6442d8a2d34ee8d4ade8e6db": 2021,
+            "6671c479d34e84915adb7536": 2023,
         }
-        download_path = self.download_directory / f"usgsuspvdb_{year}.zip"
-        await self.download_zipfile(crosswalk_urls[year], download_path)
+        try:
+            year = crosswalk_urls[dataset_id]
+        except KeyError:
+            raise KeyError(
+                f"Dataset ID {dataset_id} at link {link} isn't mapped to a year in crosswalk_urls. Is this a new year of data?"
+            )
+        download_path = self.download_directory / f"usgsuspvdb-{year}.zip"
+        download_link = f"https://www.sciencebase.gov/catalog/file/get/{dataset_id}"
+
+        await self.download_zipfile(download_link, download_path)
 
         return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/usgsuspvdb.py
+++ b/src/pudl_archiver/archivers/usgsuspvdb.py
@@ -1,0 +1,40 @@
+"""Download USGS USPVDB -- U.S. Large-Scale Solar Photovoltaic Database."""
+
+import re
+from pathlib import Path
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+
+# Note: Using non s3:// link here as compatibility between asyncio and botocore is
+# complex.
+BASE_URL = "https://oedi-data-lake.s3.amazonaws.com/ATB/electricity/parquet"
+LINK_URL = "https://data.openei.org/s3_viewer?bucket=oedi-data-lake&prefix=ATB%2Felectricity%2Fparquet%2F"
+
+
+class NrelAtbArchiver(AbstractDatasetArchiver):
+    """NREL ATB for Electricity archiver."""
+
+    name = "nrelatb"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Using years gleaned from LINK_URL, iterate and download all files."""
+        link_pattern = re.compile(r"parquet%2F(\d{4})")
+        for link in await self.get_hyperlinks(LINK_URL, link_pattern):
+            matches = link_pattern.search(link)
+            if not matches:
+                continue
+            year = int(matches.group(1))
+            if self.valid_year(year):
+                yield self.get_year_resource(year)
+
+    async def get_year_resource(self, year: int) -> tuple[Path, dict]:
+        """Download parquet file."""
+        url = f"{BASE_URL}/{year}/ATBe.parquet"
+        download_path = self.download_directory / f"nrelatb-{year}.parquet"
+        await self.download_file(url, download_path)
+
+        return ResourceInfo(local_path=download_path, partitions={"year": year})

--- a/src/pudl_archiver/archivers/usgsuspvdb.py
+++ b/src/pudl_archiver/archivers/usgsuspvdb.py
@@ -24,8 +24,8 @@ class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
     at https://energy.usgs.gov/uspvdb/data/" but the filename will include the date of the release
     which is not predictable.
 
-    This code will have to be updated if new versions are available. Maybe check for the number of
-    datasets returned in the catalog somehow?
+    This code will have to be updated if new versions are available. It will raise an
+    error if a version is found that isn't already mapped.
     """
 
     name = "usgsuspvdb"
@@ -36,32 +36,34 @@ class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
         link_pattern = re.compile(r"\/item\/(\w+)$")
         for link in await self.get_hyperlinks(BASE_URL, link_pattern):
             dataset_id = link_pattern.search(link).group(1)
-            yield self.get_crosswalk_zip(link, dataset_id)
+            yield self.get_version_resource(link, dataset_id)
 
-    async def get_crosswalk_zip(self, link: str, dataset_id: str) -> tuple[Path, dict]:
-        """Download entire dataset as a zipfile.
+    async def get_version_resource(
+        self, link: str, dataset_id: str
+    ) -> tuple[Path, dict]:
+        """Download entire dataset as a zipfile for a given year.
 
         The `get` URLs are found on:
         * https://www.sciencebase.gov/catalog/item/6442d8a2d34ee8d4ade8e6db
         * https://www.sciencebase.gov/catalog/item/6671c479d34e84915adb7536
 
-        The date on the file is the date of publication, while we want the date of the
-        partition to correspond to data availability. For simplicity, we map this manually
-        and alert ourselves when any new data is published.
+        The date on the file is the date of publication, and the time range covered
+        by the dataset varies from version to version. To keep things simple, we map
+        urls to their version manually and alert ourselves when any new data is published.
         """
         crosswalk_urls = {
-            "6442d8a2d34ee8d4ade8e6db": 2021,
-            "6671c479d34e84915adb7536": 2023,
+            "6442d8a2d34ee8d4ade8e6db": "1.0",
+            "6671c479d34e84915adb7536": "2.0",
         }
         try:
-            year = crosswalk_urls[dataset_id]
+            version = crosswalk_urls[dataset_id]
         except KeyError:
             raise KeyError(
-                f"Dataset ID {dataset_id} at link {link} isn't mapped to a year in crosswalk_urls. Is this a new year of data?"
+                f"Dataset ID {dataset_id} at link {link} isn't mapped to a version in crosswalk_urls. Is this a new version of data?"
             )
-        download_path = self.download_directory / f"usgsuspvdb-{year}.zip"
+        download_path = self.download_directory / f"usgsuspvdb-{version}.zip"
         download_link = f"https://www.sciencebase.gov/catalog/file/get/{dataset_id}"
 
         await self.download_zipfile(download_link, download_path)
 
-        return ResourceInfo(local_path=download_path, partitions={"year": year})
+        return ResourceInfo(local_path=download_path, partitions={"version": version})

--- a/src/pudl_archiver/archivers/usgsuspvdb.py
+++ b/src/pudl_archiver/archivers/usgsuspvdb.py
@@ -35,7 +35,7 @@ class UsgsUsPvDbArchiver(AbstractDatasetArchiver):
     async def get_crosswalk_zip(self, year: int) -> tuple[Path, dict]:
         """Download entire dataset as a zipfile.
 
-        The `get` URLs are found on: 
+        The `get` URLs are found on:
         * https://www.sciencebase.gov/catalog/item/6442d8a2d34ee8d4ade8e6db
         * https://www.sciencebase.gov/catalog/item/6671c479d34e84915adb7536
         """

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -22,7 +22,7 @@ def parse_main(args=None):
         "--datasets",
         nargs="*",
         help="Name of the Zenodo deposition.",
-        choices=list(ARCHIVERS.keys()),
+        choices=sorted(ARCHIVERS.keys()),
     )
     parser.add_argument(
         "--only-years",

--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -71,6 +71,7 @@ phmsagas:
   production_doi: 10.5281/zenodo.7683351
   sandbox_doi: 10.5072/zenodo.45279
 usgsuspvdb:
+  production_doi: 10.5281/zenodo.14736285
   sandbox_doi: 10.5072/zenodo.157776
 vcerare:
   production_doi: 10.5281/zenodo.13937522

--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -70,6 +70,8 @@ nrelatb:
 phmsagas:
   production_doi: 10.5281/zenodo.7683351
   sandbox_doi: 10.5072/zenodo.45279
+usgsuspvdb:
+  sandbox_doi: 10.5072/zenodo.157776
 vcerare:
   production_doi: 10.5281/zenodo.13937522
   sandbox_doi: 10.5072/zenodo.118136


### PR DESCRIPTION
# Overview

Closes https://github.com/catalyst-cooperative/pudl-archiver/issues/515
Taking over from #535.

What problem does this address?
Adding USGS PV database to our archiving workflows.

What did you change in this PR?
Added a new subclass of `AbstractDatasetArchiver` called usgsuspvdb.py. Also fixed a personal annoyance and sorted the list of archivers in the CLI help function to make it easier to find what you're misspelling.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Published sandbox DOI is here for review: https://sandbox.zenodo.org/records/157777

# Question for reviewer
The 2023 publication contains data up through 2021, so I've used `{year = 2021}` in line with how we treat the majority of our datasets. And 2024 -> data up through 2023. Does this make sense to you, reviewer?

# To-do list

```[tasklist]
- [x] once approved, run prod archive
- [x] add prod doi to yaml
- [x] add to GHA
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
