### PR TITLE
Make possible to create archivers from GHA

### DIFF
--- a/.github/workflows/create-archiver.yml
+++ b/.github/workflows/create-archiver.yml
@@ -1,0 +1,122 @@
+---
+name: run-archiver
+
+on:
+  workflow_dispatch:
+    inputs:
+      datasets:
+        description: 'Comma-separated list of datasets to archive (e.g., "ferc2","ferc6").'
+        default: '"eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiawater","eia_bulk_elec","epacamd_eia","epacems","ferc1","ferc2","ferc6","ferc60","ferc714","gridpathratoolkit","mshamines","nrelatb","phmsagas","usgsuspvdb","vcerare"'
+        required: true
+        type: string
+      sandbox:
+        description: "Run archiver on the sandbox server?"
+        default: false
+        required: true
+        type: boolean
+
+jobs:
+  archive-run:
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        # Note that we can't pass global env variables to the matrix, so we manually reproduce the list of datasets here.
+        dataset: ${{ fromJSON(format('[{0}]', inputs.datasets || '"eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiawater","eia_bulk_elec","epacamd_eia","epacems","ferc1","ferc2","ferc6","ferc60","ferc714","gridpathratoolkit","mshamines","nrelatb","phmsagas","usgsuspvdb","vcerare"' )) }}
+      fail-fast: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set default GCP credentials
+        id: gcloud-auth
+        continue-on-error: true
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "pudl-sources@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+
+      - name: Install Conda environment using mamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: environment.yml
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            channel_priority: strict
+
+      - name: Log the conda environment
+        run: |
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+
+      - name: Create archive for ${{ matrix.dataset }}
+        env:
+          ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
+          ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+          EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
+          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
+          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
+        if: ${{ inputs.sandbox == false }}
+        run: |
+          pudl_archiver --datasets ${{ matrix.dataset }} --initialize --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
+
+      - name: Create sandbox archive for ${{ matrix.dataset }}
+        env:
+          ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
+          ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+          EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
+          ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
+          ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
+        if: ${{ inputs.sandbox == true }}
+        run: |
+          pudl_archiver --datasets ${{ matrix.dataset }} --initialize --sandbox --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
+
+      - name: Upload run summaries
+        if: always()
+        id: upload_summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-summaries-${{ matrix.dataset }}
+          path: ${{ matrix.dataset }}_run_summary.json
+
+  archive-notify:
+    runs-on: ubuntu-latest
+    needs:
+      - archive-run
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download summaries
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          pattern: run-summaries-*
+          merge-multiple: true
+      - name: show summaries
+        run: ls -R
+      - name: Munge summaries together
+        id: all_summaries
+        run: |
+          {
+            echo "SLACK_PAYLOAD<<EOF"
+            ./scripts/make_slack_notification_message.py --summary-files *_run_summary.json | tee slack-payload.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post update to pudl-deployment
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          payload: |
+            text: "Created new archiver(s)."
+            blocks: ${{ steps.all_summaries.outputs.SLACK_PAYLOAD }}
+            channel: "C03FHB9N0PQ"


### PR DESCRIPTION
# Overview

What problem does this address?
Sometimes the barrier to testing an archiving is our internet connection. GHA resolves this nicely, but we currently can only use it to update existing archives. This extends the existing GHA workflow to allow for the creation of new sandbox and production archive drafts. This is low risk because they are drafts, not published directly! This also deprecates the use of the `conda-test`, which hasn't been updated in some time and isn't currently working as expected (it is impossible to update the conda environment).

What did you change in this PR?
Created a new workflow file that initializes new archivers (prod and sandbox).

# Testing

How did you make sure this worked? How can a reviewer verify this?
We'll need to merge the workflow file to able to test it.

# To-do list

```[tasklist]
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
