### PR TITLE
Add --list option to CLI to print the names of all available archivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ pudl_archiver --datasets {list_of_datasources}
 
 This command will download the latest available data and create archives for each
 requested datasource requested. The supported datasources include `censusdp1tract`,
-`eia_bulk_elec`, `eia176`, `eia191`, `eia757a`,`eia860`, `eia860m`, `eia861`, `eia923`,
-`eia930`, `eiaaeo`, `eiawater`, `epacems`, `epacamd_eia`, `ferc1`, `ferc2`, `ferc6`,
-`ferc60`, `ferc714`, `nrelatb`, `phmsagas`, `mshamines`.
+`eia_bulk_elec`, `eia176`, `eia191`, and many more; see the full list with
+`pudl_archiver --list`.
 
 There are also five optional flags available:
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ pudl_archiver --datasets {list_of_datasources}
 ```
 
 This command will download the latest available data and create archives for each
-requested datasource requested. The supported datasources include `censusdp1tract`,
-`eia_bulk_elec`, `eia176`, `eia191`, and many more; see the full list with
+requested datasource requested. The supported datasources include `eia860`, `eia923`,
+`ferc1`, `epacems`, and many more; see the full list of available datasets with
 `pudl_archiver --list`.
 
 There are also five optional flags available:

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -25,6 +25,11 @@ def parse_main(args=None):
         choices=sorted(ARCHIVERS.keys()),
     )
     parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List all available archivers.",
+    )
+    parser.add_argument(
         "--only-years",
         nargs="*",
         help="Years to download data for. Supported datasets: censusdp1tract, censuspep, "
@@ -96,6 +101,12 @@ async def archiver_entry(args=None):
     log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
     coloredlogs.install(fmt=log_format, level=logging.INFO, logger=logger)
     args = parse_main(args)
+
+    if args.list:
+        for name in sorted(ARCHIVERS.keys()):
+            print(name)
+        return
+
     datasets = args.datasets
     if args.all:
         datasets = ARCHIVERS.keys()


### PR DESCRIPTION
# Overview

Closes #553.

What problem does this address?

What did you change in this PR?

* Add `--list` CLI option which prints each archiver name and then exits
* Update README to list a few sample archivers and then direct user to `--list` to see the rest.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```bash
$ pudl_archiver --list
[...]
$ pudl_archiver --help | grep list
```

# To-do list

```[tasklist]
- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
