### PR TITLE
Add archiver for NREL Standard Scenarios

### DIFF
--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -321,6 +321,7 @@ class AbstractDatasetArchiver(ABC):
         Args:
             text: text containing HTML.
             filter_pattern: If present, only return links that contain pattern.
+            context: String used in error messages to describe what text was being searched.
         """
         parser = _HyperlinkExtractor()
         parser.feed(text)

--- a/src/pudl_archiver/archivers/classes.py
+++ b/src/pudl_archiver/archivers/classes.py
@@ -84,9 +84,7 @@ async def _download_file(
     post: bool = False,
     **kwargs,
 ):
-    method = session.get
-    if post:
-        method = session.post
+    method = session.post if post else session.get
     async with method(url, **kwargs) as response:
         with file.open("wb") if isinstance(file, Path) else nullcontext(file) as f:
             async for chunk in response.content.iter_chunked(1024):
@@ -337,7 +335,7 @@ class AbstractDatasetArchiver(ABC):
         # Warn if no links are found
         if not hyperlinks:
             self.logger.warning(
-                f"The archiver couldn't find any hyperlinks{('that match: ' + filter_pattern.pattern) if filter_pattern else ''}."
+                f"The archiver couldn't find any hyperlinks {('that match: ' + filter_pattern.pattern) if filter_pattern else ''}."
                 f"Make sure your filter_pattern is correct, and check if the structure of the page is not what you expect it to be."
             )
 

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -112,7 +112,7 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
                 uuid=project_uuid,
                 file_ids=[
                     (f["id"], f"NRELSS {project_year}  {f['scenario']}  {f['location_type']}.csv".replace(" ","_"))
-                    for f in file_list["files"] if f["file_type"] == "CSV"
+                    for f in file_list["files"] if (f["file_type"] == "CSV" or project_year == 2020)
                 ],
                 year=project_year
             )
@@ -129,7 +129,7 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
         zip_path = self.download_directory / f"{self.name}-{year}.zip"
         data_paths_in_archive = set()
         # report
-        self.logger.info(f"Downloading report {report[0]} from {report[1]}")
+        self.logger.info(f"Downloading report {year} {report[0]} from {report[1]}")
         download_path = self.download_directory / report[0]
         await self.download_file(report[1], download_path)
         self.add_to_archive(
@@ -143,7 +143,7 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
         download_path.unlink()
         
         for file_id,filename in file_ids:
-            self.logger.info(f"Downloading file {file_id} {uuid}")
+            self.logger.info(f"Downloading file {year} {file_id} {uuid}")
 #             file_resp = await retry_async(
 #                 self.session.post,
 #                 ["https://scenarioviewer.nrel.gov/api/download/"],

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -182,7 +182,7 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
         # reports: direct URL
         for filename, url in reports:
             self.logger.info(f"Downloading report {year} {filename} {uuid} from {url}")
-            self.download_add_to_archive_and_unlink(url, filename, zip_path)
+            await self.download_add_to_archive_and_unlink(url, filename, zip_path)
 
         # files: API call
         for filename, file_id in file_ids:
@@ -191,6 +191,7 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
             await self.download_file(
                 API_URL_FILE_DOWNLOAD,
                 download_path,
+                post=True,
                 data={"project_uuid": uuid, "file_ids": file_id},
             )
             self.add_to_archive(

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -1,5 +1,9 @@
 """Download NREL Standard Scenarios data."""
 
+import aiohttp
+from contextlib import nullcontext
+import io
+from pathlib import Path
 import re
 
 from pudl_archiver.archivers.classes import (
@@ -15,6 +19,13 @@ from pudl_archiver.utils import retry_async
 # able to hard-code it for now:
 REPORT_2021 = "https://www.nrel.gov/docs/fy22osti/80641.pdf"
 
+async def _download_file_post(
+    session: aiohttp.ClientSession, url: str, file: Path | io.BytesIO, **kwargs
+):
+    async with session.post(url, **kwargs) as response:
+        with file.open("wb") if isinstance(file, Path) else nullcontext(file) as f:
+            async for chunk in response.content.iter_chunked(1024):
+                f.write(chunk)
 
 class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
     """NREL Standard Scenarios archiver."""
@@ -63,42 +74,50 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
                     f"We expect all years except 2021 to have a citation with a link to the report, but {project_year} does not:"
                     f"{scenario_project}"
                 )
-            download_links = {f"{m.group('fy')}_{m.group('number')}": report_link}
+                    
             file_list = await post_to_json(
                 "https://scenarioviewer.nrel.gov/api/file-list/",
                 project_uuid=project_uuid,
             )
-            for file_record in (
-                f for f in file_list["files"] if f["file_type"] == "CSV"
-            ):
-                file_resp = await retry_async(
-                    self.session.post,
-                    ["https://scenarioviewer.nrel.gov/api/download/"],
-                    kwargs={
-                        "data":{"project_uuid": project_uuid, "file_ids": file_record["id"]},
-                        "kwargs":{"allow_redirects":False}},
-                )
-                file_headers = file_resp.headers
-                download_filename = f"{file_record['location_type']}.csv"
+            # for file_record in (
+#                 
+#             ):
+#                 file_resp = await retry_async(
+#                     self.session.post,
+#                     ["https://scenarioviewer.nrel.gov/api/download/"],
+#                     kwargs={
+#                         "data":{"project_uuid": project_uuid, "file_ids": file_record["id"]},
+#                         "kwargs":{"allow_redirects":False}},
+#                 )
+#                 file_headers = file_resp.headers
+#                 download_filename = f"{file_record['location_type']}.csv"
+# 
+#                 if "Location" not in file_headers:
+#                     for h in file_headers:
+#                         print(f"{h}: {file_headers[h]}")
+#                 m = filename_pattern.search(file_headers["Location"])
+#                 if m:
+#                     download_filename = m.groups(1)
+#                 else:
+#                     # this will give us e.g.
+#                     # (for 2023-2024) "ALL Transmission Capacities.csv" "ALL States.csv"
+#                     # (for previous years) "Electrification Nations.csv" "High Natural Gas Prices States.csv"
+#                     download_filename = (
+#                         f"{file_record['scenario']} {file_record['location_type']}.csv"
+#                     )
+# 
+#                 download_links[download_filename] = file_headers["Location"]
+            yield self.get_year_resource(
+                report=(f"{m.group('fy')}_{m.group('number')}", report_link),
+                uuid=project_uuid,
+                file_ids=[
+                    (f["id"], f"NRELSS {project_year}  {f['scenario']}  {f['location_type']}.csv".replace(" ","_"))
+                    for f in file_list["files"] if f["file_type"] == "CSV"
+                ],
+                year=project_year
+            )
 
-                if "Location" not in file_headers:
-                    for h in file_headers:
-                        print(f"{h}: {file_headers[h]}")
-                m = filename_pattern.search(file_headers["Location"])
-                if m:
-                    download_filename = m.groups(1)
-                else:
-                    # this will give us e.g.
-                    # (for 2023-2024) "ALL Transmission Capacities.csv" "ALL States.csv"
-                    # (for previous years) "Electrification Nations.csv" "High Natural Gas Prices States.csv"
-                    download_filename = (
-                        f"{file_record['scenario']} {file_record['location_type']}.csv"
-                    )
-
-                download_links[download_filename] = file_headers["Location"]
-            yield self.get_year_resource(download_links, project_year)
-
-    async def get_year_resource(self, links: dict[str, str], year: int) -> ResourceInfo:
+    async def get_year_resource(self, report, uuid, file_ids, year: int) -> ResourceInfo:
         """Download all available data for a year.
 
         Resulting resource contains one pdf of the scenario report, and a set of CSVs for different scenarios and geo levels.
@@ -109,10 +128,36 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
         """
         zip_path = self.download_directory / f"{self.name}-{year}.zip"
         data_paths_in_archive = set()
-        for filename, link in sorted(links.items()):
-            self.logger.info(f"Downloading {filename} from {link}")
+        # report
+        self.logger.info(f"Downloading report {report[0]} from {report[1]}")
+        download_path = self.download_directory / report[0]
+        await self.download_file(report[1], download_path)
+        self.add_to_archive(
+            zip_path=zip_path,
+            filename=report[0],
+            blob=download_path.open("rb"),
+        )
+        data_paths_in_archive.add(report[0])
+        # Don't want to leave multiple giant files on disk, so delete
+        # immediately after they're safely stored in the ZIP
+        download_path.unlink()
+        
+        for file_id,filename in file_ids:
+            self.logger.info(f"Downloading file {file_id} {uuid}")
+#             file_resp = await retry_async(
+#                 self.session.post,
+#                 ["https://scenarioviewer.nrel.gov/api/download/"],
+#                 kwargs={
+#                     "data":{"project_uuid": project_uuid, "file_ids": file_record["id"]},
+#                     "kwargs":{"allow_redirects":False}},
+#             )
             download_path = self.download_directory / filename
-            await self.download_file(link, download_path)
+            await retry_async(
+                _download_file_post, 
+                [self.session, "https://scenarioviewer.nrel.gov/api/download/", download_path],
+                kwargs={"data":{"project_uuid": uuid, "file_ids": file_id}}
+            )
+#             await self.download_file(link, download_path)
             self.add_to_archive(
                 zip_path=zip_path,
                 filename=filename,

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -111,7 +111,7 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
                 report=(f"{m.group('fy')}_{m.group('number')}", report_link),
                 uuid=project_uuid,
                 file_ids=[
-                    (f["id"], f"NRELSS {project_year}  {f['scenario']}  {f['location_type']}.csv".replace(" ","_"))
+                    (f["id"], f"NRELSS {project_year}  {f['scenario']}  {f['location_type']}.{f['file_type']}".replace(" ","_").lower())
                     for f in file_list["files"] if (f["file_type"] == "CSV" or project_year == 2020)
                 ],
                 year=project_year

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -79,34 +79,6 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
                 "https://scenarioviewer.nrel.gov/api/file-list/",
                 project_uuid=project_uuid,
             )
-            # for file_record in (
-#                 
-#             ):
-#                 file_resp = await retry_async(
-#                     self.session.post,
-#                     ["https://scenarioviewer.nrel.gov/api/download/"],
-#                     kwargs={
-#                         "data":{"project_uuid": project_uuid, "file_ids": file_record["id"]},
-#                         "kwargs":{"allow_redirects":False}},
-#                 )
-#                 file_headers = file_resp.headers
-#                 download_filename = f"{file_record['location_type']}.csv"
-# 
-#                 if "Location" not in file_headers:
-#                     for h in file_headers:
-#                         print(f"{h}: {file_headers[h]}")
-#                 m = filename_pattern.search(file_headers["Location"])
-#                 if m:
-#                     download_filename = m.groups(1)
-#                 else:
-#                     # this will give us e.g.
-#                     # (for 2023-2024) "ALL Transmission Capacities.csv" "ALL States.csv"
-#                     # (for previous years) "Electrification Nations.csv" "High Natural Gas Prices States.csv"
-#                     download_filename = (
-#                         f"{file_record['scenario']} {file_record['location_type']}.csv"
-#                     )
-# 
-#                 download_links[download_filename] = file_headers["Location"]
             yield self.get_year_resource(
                 report=(f"{m.group('fy')}_{m.group('number')}", report_link),
                 uuid=project_uuid,
@@ -147,20 +119,12 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
         
         for file_id,filename in file_ids:
             self.logger.info(f"Downloading file {year} {file_id} {uuid}")
-#             file_resp = await retry_async(
-#                 self.session.post,
-#                 ["https://scenarioviewer.nrel.gov/api/download/"],
-#                 kwargs={
-#                     "data":{"project_uuid": project_uuid, "file_ids": file_record["id"]},
-#                     "kwargs":{"allow_redirects":False}},
-#             )
             download_path = self.download_directory / filename
             await retry_async(
                 _download_file_post, 
                 [self.session, "https://scenarioviewer.nrel.gov/api/download/", download_path],
                 kwargs={"data":{"project_uuid": uuid, "file_ids": file_id}}
             )
-#             await self.download_file(link, download_path)
             self.add_to_archive(
                 zip_path=zip_path,
                 filename=filename,
@@ -173,5 +137,5 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
         return ResourceInfo(
             local_path=zip_path,
             partitions={"years": year},
-            layout=ZipLayout(file_paths=data_paths_in_archive),
+            #layout=ZipLayout(file_paths=data_paths_in_archive), # can't use ZipLayout bc these CSVs have a multi-row header and pandas throws a tantrum
         )

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -35,6 +35,12 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
     ) -> tuple[str, int, list, list]:
         """Gather all the information needed to download a single project.
 
+        We collect:
+        - The project UUID, which is used for future API calls
+        - The project year, which is used for branch logic and file naming
+        - Any PDF reports that accompany the data. PDF report URLs are not provided in a dedicated field in the project response, but are part of an HTML value for the description or citation in the project. Sometimes this field is simply blank, and we need to use a hard-coded exception.
+        - A list of data files. The fetching machinery for data files does not provide great filenames, so we construct a well-ordered filename for each programmatically.
+
         Args:
             scenario_project: dictionary representing a single project, as extracted from /api/projects/ JSON
 
@@ -100,9 +106,8 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
 
         Basic flow:
             1. Fetch the list of projects. The scenario viewer includes Standard scenarios, Cambium scenarios, and a few other types, so we filter down using the project name.
-            2. Pull out metadata for matching projects: uuid, year, and links to any PDF reports. PDF report URLs are not provided in a dedicated field in the project response, but are part of an HTML value for the description or citation in the project. Sometimes this field is simply blank, and we need to use a hard-coded exception.
-            3. Fetch the list of data files for the project, and construct a well-ordered filename for each.
-            4. Download and package all files for the project, and yield its ResourceInfo.
+            2. Pull out metadata for matching projects: uuid, year, links to any PDF reports, and data files.
+            3. Download and package all files for the project, and yield its ResourceInfo.
         """
         project_records = await self.get_json(API_URL_PROJECTS_LIST)
         for scenario_project in (

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -111,7 +111,10 @@ class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
                 report=(f"{m.group('fy')}_{m.group('number')}", report_link),
                 uuid=project_uuid,
                 file_ids=[
-                    (f["id"], f"NRELSS {project_year}  {f['scenario']}  {f['location_type']}.{f['file_type']}".replace(" ","_").lower())
+                    (
+                        f["id"], 
+                        f"NRELSS {project_year}  {f['scenario']}  {f['location_type']}.{f['file_type']}".replace(" ","_").replace("%","pct").replace(",","").lower()
+                    )
                     for f in file_list["files"] if (f["file_type"] == "CSV" or project_year == 2020)
                 ],
                 year=project_year

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -7,7 +7,6 @@ from pudl_archiver.archivers.classes import (
     ArchiveAwaitable,
     ResourceInfo,
 )
-from pudl_archiver.utils import retry_async
 
 API_URL_PROJECTS_LIST = "https://scenarioviewer.nrel.gov/api/projects/"
 API_URL_FILE_LIST = "https://scenarioviewer.nrel.gov/api/file-list/"
@@ -22,24 +21,45 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
     """Base class for archiving projects from the NREL Scenario Viewer."""
 
     project_year_pattern: re.Pattern
-    project_startswith: str
-    report_section: str
-    file_naming_order: tuple[str]
+    """Pattern for extracting the project year from the project list response JSON.
 
-    def handle_report_link_exceptions(self, project_year: str) -> str:
-        """Provide hard-coded exceptions for years where the normal report URL locator doesn't work."""
-        return ""
+    Must include a capture group called 'year'."""
+    project_startswith: str
+    """Filter: only process projects with a name that starts with this string."""
+    report_section: str
+    """Key within the file-list response JSON which contains the HTML link to PDF reports."""
+    file_naming_order: tuple[str]
+    """Keys within the file-list response JSON to include, in order, in the name of the downloaded file."""
+
+    def handle_report_link_exceptions(
+        self, project_year: str, scenario_project: dict
+    ) -> str:
+        """Provide hard-coded exceptions for years where the normal report URL locator doesn't work.
+
+        This method is only called if a report URL was not found in the
+        self.report_section key of the file-list response JSON. If this happens but no
+        known exceptions exist, we raise an AssertionError. This will happen automatically
+        if subclasses do not override, or via super() if they do.
+        """
+        raise AssertionError(
+            f"We expect all projects to have a {self.report_section} with a link to the report PDF, but {project_year} does not:\n"
+            f"{scenario_project}"
+        )
 
     async def collect_project_info(
         self, scenario_project: dict
-    ) -> tuple[str, int, list, list]:
+    ) -> tuple[str, int, list, list] | None:
         """Gather all the information needed to download a single project.
 
         We collect:
         - The project UUID, which is used for future API calls
         - The project year, which is used for branch logic and file naming
-        - Any PDF reports that accompany the data. PDF report URLs are not provided in a dedicated field in the project response, but are part of an HTML value for the description or citation in the project. Sometimes this field is simply blank, and we need to use a hard-coded exception.
-        - A list of data files. The fetching machinery for data files does not provide great filenames, so we construct a well-ordered filename for each programmatically.
+        - Any PDF reports that accompany the data. PDF report URLs are not provided in a
+          dedicated field in the project response, but are part of an HTML value for the
+          description or citation in the project. Sometimes this field is simply blank,
+          and we need to use a hard-coded exception.
+        - A list of data files. The fetching machinery for data files does not provide
+          filenames, so we construct a well-ordered filename for each programmatically.
 
         Args:
             scenario_project: dictionary representing a single project, as extracted from /api/projects/ JSON
@@ -54,19 +74,24 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
         project_uuid = scenario_project["uuid"]
         m = self.project_year_pattern.search(scenario_project["name"])
         if not m:
-            return (False,) * 3
+            # Then we can't pull the project year out of the name like we expect to.
+            # Call for help:
+            raise AssertionError(
+                f"We expect all projects starting with {self.projects_startswith} to match {self.project_year_pattern}, but {scenario_project['name']} does not:\n"
+                f"{scenario_project}"
+            )
         project_year = int(m.group("year"))
 
         report_links = self.get_hyperlinks_from_text(
-            scenario_project[self.report_section], REPORT_URL_PATTERN
+            scenario_project[self.report_section],
+            REPORT_URL_PATTERN,
+            scenario_project["name"],
         )
         if not report_links:
-            report_links = {self.handle_report_link_exceptions(project_year)}
-        if not report_links:
-            raise AssertionError(
-                f"We expect all projects to have a {self.report_section} with a link to the report PDF, but {project_year} does not:\n"
-                f"{scenario_project}"
-            )
+            report_links = {
+                self.handle_report_link_exceptions(project_year, scenario_project)
+            }
+
         report_data = []
         for report_link in report_links:
             m = REPORT_URL_PATTERN.search(report_link)
@@ -74,14 +99,13 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
                 raise AssertionError(
                     f"Bad report link {report_link} found in {scenario_project['name']} {project_uuid}: {scenario_project}"
                 )
+            # Generate a new report entry with a filename and link, e.g.,
+            # (fy17osti_66939.pdf, https://www.nrel.gov/docs/fy17osti/66939.pdf)
             report_data.append((f"{m.group('fy')}_{m.group('number')}", report_link))
 
-        file_list_resp = await retry_async(
-            self.session.post,
-            [API_URL_FILE_LIST],
-            kwargs={"data": {"project_uuid": project_uuid}},
+        file_list = await self.get_json(
+            API_URL_FILE_LIST, post=True, data={"project_uuid": project_uuid}
         )
-        file_list = await retry_async(file_list_resp.json)
 
         return (
             project_uuid,
@@ -89,9 +113,14 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
             report_data,
             [
                 (
-                    f"{self.name.upper()} {project_year}  {'  '.join(f[x] for x in self.file_naming_order)}.{f['file_type']}".replace(
-                        " ", "_"
+                    # The API doesn't provide us with a filename, so we generate one from
+                    # fields of the file entry in self.file_naming_order order, e.g.,
+                    # nrelss_2016__cooling_water_restrictions__nations.csv
+                    # nrelcambium_2021__mid-case_95_by_2035__all__tod__balancing_areas.zip
+                    (
+                        f"{self.name} {project_year}  {'  '.join(f[x] for x in self.file_naming_order)}.{f['file_type']}"
                     )
+                    .replace(" ", "_")
                     .replace("%", "pct")
                     .replace(",", "")
                     .lower(),
@@ -105,8 +134,11 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
         """Download NREL Scenario resources.
 
         Basic flow:
-            1. Fetch the list of projects. The scenario viewer includes Standard scenarios, Cambium scenarios, and a few other types, so we filter down using the project name.
-            2. Pull out metadata for matching projects: uuid, year, links to any PDF reports, and data files.
+            1. Fetch the list of projects. The scenario viewer includes Standard
+               scenarios, Cambium scenarios, and a few other types, so we filter down
+               using the project name.
+            2. Pull out metadata for matching projects: uuid, year, links to any PDF
+               reports, and data files.
             3. Download and package all files for the project, and yield its ResourceInfo.
         """
         project_records = await self.get_json(API_URL_PROJECTS_LIST)
@@ -119,13 +151,12 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
                 report_data,
                 file_ids,
             ) = await self.collect_project_info(scenario_project)
-            if project_uuid:
-                yield self.get_project_resource(
-                    uuid=project_uuid,
-                    year=project_year,
-                    reports=report_data,
-                    file_ids=file_ids,
-                )
+            yield self.get_project_resource(
+                uuid=project_uuid,
+                year=project_year,
+                reports=report_data,
+                file_ids=file_ids,
+            )
 
     async def get_project_resource(
         self,
@@ -136,7 +167,9 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
     ) -> ResourceInfo:
         """Download all available data for a project.
 
-        Resulting resource contains PDFs of the scenario report(s), and a set of CSVs or ZIPs for different slices.
+        One NREL "project" corresponds to one year of data for PUDL. The resulting
+        resource contains PDFs of the scenario report(s), and a set of CSVs or ZIPs for
+        different slices.
 
         Args:
             uuid: identifier for the project
@@ -169,6 +202,8 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
             # immediately after they're safely stored in the ZIP
             download_path.unlink()
 
+        # we can't use ZipLayout here because these CSVs have a multi-row header and we
+        # don't yet have a way to tell pandas about it, so validation would fail.
         return ResourceInfo(
             local_path=zip_path,
             partitions={"years": year},
@@ -184,11 +219,11 @@ class NrelStandardScenariosArchiver(AbstractNrelScenarioArchiver):
     report_section = "citation"
     file_naming_order = ("scenario", "location_type")
 
-    def handle_report_link_exceptions(self, project_year):
+    def handle_report_link_exceptions(self, project_year, scenario_project):
         """Hard-coded exception for project year 2021."""
         if project_year == 2021:
             # The citation field for Standard Scenarios 2021 is blank, but they linked to the
             # 2021 report from the description of one of the other available projects, so we're
             # able to hard-code it for now:
             return "https://www.nrel.gov/docs/fy22osti/80641.pdf"
-        return ""
+        return super().handle_report_link_exceptions(project_year, scenario_project)

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -1,0 +1,117 @@
+"""Download NREL Standard Scenarios data."""
+
+import re
+
+from pudl_archiver.archivers.classes import (
+    AbstractDatasetArchiver,
+    ArchiveAwaitable,
+    ResourceInfo,
+)
+from pudl_archiver.frictionless import ZipLayout
+from pudl_archiver.utils import retry_async
+
+# The citation field for Standard Scenarios 2021 is blank, but they linked to the
+# 2021 report from the description of one of the other available projects, so we're
+# able to hard-code it for now:
+REPORT_2021 = "https://www.nrel.gov/docs/fy22osti/80641.pdf"
+
+
+class NrelStandardScenariosArchiver(AbstractDatasetArchiver):
+    """NREL Standard Scenarios archiver."""
+
+    name = "nrelss"
+
+    async def get_resources(self) -> ArchiveAwaitable:
+        """Download NREL Standard Scenarios resources."""
+
+        async def post_to_json(url, **kwargs):
+            resp = await retry_async(self.session.post, [url], data=kwargs)
+            return await retry_async(resp.json)
+
+        project_year_pattern = re.compile(r"Standard Scenarios (?P<year>\d{4})")
+        report_url_pattern = re.compile(
+            r"http://www.nrel.gov/docs/(?P<fy>fy\d{2}osti)/(?P<number>\d{5}\.pdf)"
+        )
+        filename_pattern = re.compile(r"/([^/?]*/.csv)")
+
+        project_records = self.get_json("https://scenarioviewer.nrel.gov/api/projects/")
+        for scenario_project in (
+            p for p in project_records if p["name"].startswith("Standard Scenarios")
+        ):
+            project_uuid = scenario_project["uuid"]
+            m = project_year_pattern.search(scenario_project["name"])
+            if not m:
+                continue
+            project_year = int(m.group("year"))
+
+            if scenario_project["citation"]:
+                report_link = self.get_hyperlinks_from_text(
+                    scenario_project["citation"], report_url_pattern
+                ).pop()
+            elif project_year == 2021:
+                report_link = REPORT_2021
+            m = report_url_pattern.search(report_link)
+            if not m:
+                raise AssertionError(
+                    f"We expect all years except 2021 to have a citation with a link to the report, but {project_year} does not:"
+                    f"{scenario_project}"
+                )
+            download_links = {f"{m.group('fy')}_{m.group('number')}": report_link}
+            file_list = post_to_json(
+                "https://scenarioviewer.nrel.gov/api/file-list/",
+                project_uuid=project_uuid,
+            )
+            for file_record in (
+                f for f in file_list["files"] if f["file_type"] == "CSV"
+            ):
+                file_resp = await retry_async(
+                    self.session.post,
+                    ["https://scenarioviewer.nrel.gov/api/download/"],
+                    data={"project_uuid": project_uuid, "file_ids": file_record["id"]},
+                )
+                file_headers = file_resp.headers()
+                download_filename = f"{file_record['location_type']}.csv"
+
+                m = filename_pattern.search(file_headers["Location"])
+                if m:
+                    download_filename = m.groups(1)
+                else:
+                    # this will give us e.g.
+                    # (for 2023-2024) "ALL Transmission Capacities.csv" "ALL States.csv"
+                    # (for previous years) "Electrification Nations.csv" "High Natural Gas Prices States.csv"
+                    download_filename = (
+                        f"{file_record['scenario']} {file_record['location_type']}.csv"
+                    )
+
+                download_links[download_filename] = file_headers["Location"]
+            yield self.get_year_resource(download_links, project_year)
+
+    async def get_year_resource(self, links: dict[str, str], year: int) -> ResourceInfo:
+        """Download all available data for a year.
+
+        Resulting resource contains one pdf of the scenario report, and a set of CSVs for different scenarios and geo levels.
+
+        Args:
+            links: filename->URL mapping for files to download
+            year: the year we're downloading data for
+        """
+        zip_path = self.download_directory / f"{self.name}-{year}.zip"
+        data_paths_in_archive = set()
+        for filename, link in sorted(links.items()):
+            self.logger.info(f"Downloading {filename} from {link}")
+            download_path = self.download_directory / filename
+            await self.download_file(link, download_path)
+            self.add_to_archive(
+                zip_path=zip_path,
+                filename=filename,
+                blob=download_path.open("rb"),
+            )
+            data_paths_in_archive.add(filename)
+            # Don't want to leave multiple giant files on disk, so delete
+            # immediately after they're safely stored in the ZIP
+            download_path.unlink()
+        return ResourceInfo(
+            local_path=zip_path,
+            partitions={"years": year},
+            layout=ZipLayout(file_paths=data_paths_in_archive),
+        )

--- a/src/pudl_archiver/archivers/nrelss.py
+++ b/src/pudl_archiver/archivers/nrelss.py
@@ -116,11 +116,12 @@ class AbstractNrelScenarioArchiver(AbstractDatasetArchiver):
                     # The API doesn't provide us with a filename, so we generate one from
                     # fields of the file entry in self.file_naming_order order, e.g.,
                     # nrelss_2016__cooling_water_restrictions__nations.csv
-                    # nrelcambium_2021__mid-case_95_by_2035__all__tod__balancing_areas.zip
+                    # nrelcambium_2021__mid_case_95_by_2035__all__tod__balancing_areas.zip
                     (
                         f"{self.name} {project_year}  {'  '.join(f[x] for x in self.file_naming_order)}.{f['file_type']}"
                     )
                     .replace(" ", "_")
+                    .replace("-", "_")
                     .replace("%", "pct")
                     .replace(",", "")
                     .lower(),

--- a/src/pudl_archiver/metadata/sources.py
+++ b/src/pudl_archiver/metadata/sources.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pudl.metadata.constants import CONTRIBUTORS, LICENSES, KEYWORDS
+from pudl.metadata.constants import CONTRIBUTORS, LICENSES
 
 # To add a new contributor, follow the following format to add an entry to the
 # ADDL_CONTRIBUTORS dictionary below formatted like this:

--- a/src/pudl_archiver/metadata/sources.py
+++ b/src/pudl_archiver/metadata/sources.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pudl.metadata.constants import CONTRIBUTORS, LICENSES
+from pudl.metadata.constants import CONTRIBUTORS, LICENSES, KEYWORDS
 
 # To add a new contributor, follow the following format to add an entry to the
 # ADDL_CONTRIBUTORS dictionary below formatted like this:
@@ -413,5 +413,43 @@ NON_PUDL_SOURCES: dict[str, Any] = {
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
         "contributors": [CONTRIBUTORS["catalyst-cooperative"]],
+    },
+    "nrelss": {
+        "title": "NREL Standard Scenarios",
+        "path": "https://www.nrel.gov/analysis/standard-scenarios.html",
+        "description": (
+            "NREL's Standard Scenarios are a suite of forward-looking scenarios of the U.S."
+            "power sector that are updated annually to support and inform energy analysis."
+            "The Standard Scenarios are simulated using the Regional Energy Deployment System"
+            "and Distributed Generation Market Demand Model capacity expansion models and are"
+            "updated each year to provide timely information regarding power sector evolution."
+            "The scenarios have been designed to capture a range of possible power system"
+            "futures and consider a variety of factors from high vehicle electrification to"
+            "major cost declines for electricity generation technologies (e.g., using cost"
+            "inputs from the Annual Technology Baseline)."
+            "For select scenarios, the models are run using the PLEXOS software and the"
+            "Cambium tool that assembles structured data sets of hourly cost, emissions, and"
+            "operational data for modeled futures. Results are available using the Scenario"
+            "Viewer and Data Downloader."
+        ),
+        "source_file_dict": {
+            "source_format": "CSV",
+        },
+        "working_partitions": {
+            "years": list(range(2016, 2025)),
+        },
+        "contributors": [
+            CONTRIBUTORS["catalyst-cooperative"],
+        ],
+        "keywords": sorted(
+            {
+                "nrel",
+                "standard scenarios",
+            }
+            | KEYWORDS["us_govt"]
+            | KEYWORDS["electricity"]
+        ),
+        "license_raw": LICENSES["cc-by-4.0"],
+        "license_pudl": LICENSES["cc-by-4.0"],
     },
 }

--- a/src/pudl_archiver/metadata/sources.py
+++ b/src/pudl_archiver/metadata/sources.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pudl.metadata.constants import CONTRIBUTORS, LICENSES
+from pudl.metadata.constants import CONTRIBUTORS, KEYWORDS, LICENSES
 
 # To add a new contributor, follow the following format to add an entry to the
 # ADDL_CONTRIBUTORS dictionary below formatted like this:
@@ -418,18 +418,18 @@ NON_PUDL_SOURCES: dict[str, Any] = {
         "title": "NREL Standard Scenarios",
         "path": "https://www.nrel.gov/analysis/standard-scenarios.html",
         "description": (
-            "NREL's Standard Scenarios are a suite of forward-looking scenarios of the U.S."
-            "power sector that are updated annually to support and inform energy analysis."
-            "The Standard Scenarios are simulated using the Regional Energy Deployment System"
-            "and Distributed Generation Market Demand Model capacity expansion models and are"
-            "updated each year to provide timely information regarding power sector evolution."
-            "The scenarios have been designed to capture a range of possible power system"
-            "futures and consider a variety of factors from high vehicle electrification to"
-            "major cost declines for electricity generation technologies (e.g., using cost"
-            "inputs from the Annual Technology Baseline)."
-            "For select scenarios, the models are run using the PLEXOS software and the"
-            "Cambium tool that assembles structured data sets of hourly cost, emissions, and"
-            "operational data for modeled futures. Results are available using the Scenario"
+            "NREL's Standard Scenarios are a suite of forward-looking scenarios of the U.S. "
+            "power sector that are updated annually to support and inform energy analysis. "
+            "The Standard Scenarios are simulated using the Regional Energy Deployment System "
+            "and Distributed Generation Market Demand Model capacity expansion models and are "
+            "updated each year to provide timely information regarding power sector evolution. "
+            "The scenarios have been designed to capture a range of possible power system "
+            "futures and consider a variety of factors from high vehicle electrification to "
+            "major cost declines for electricity generation technologies (e.g., using cost "
+            "inputs from the Annual Technology Baseline). "
+            "For select scenarios, the models are run using the PLEXOS software and the "
+            "Cambium tool that assembles structured data sets of hourly cost, emissions, and "
+            "operational data for modeled futures. Results are available using the Scenario "
             "Viewer and Data Downloader."
         ),
         "source_file_dict": {
@@ -442,12 +442,14 @@ NON_PUDL_SOURCES: dict[str, Any] = {
             CONTRIBUTORS["catalyst-cooperative"],
         ],
         "keywords": sorted(
-            {
-                "nrel",
-                "standard scenarios",
-            }
-            | KEYWORDS["us_govt"]
-            | KEYWORDS["electricity"]
+            set(
+                [
+                    "nrel",
+                    "standard scenarios",
+                ]
+                + KEYWORDS["us_govt"]
+                + KEYWORDS["electricity"]
+            )
         ),
         "license_raw": LICENSES["cc-by-4.0"],
         "license_pudl": LICENSES["cc-by-4.0"],


### PR DESCRIPTION
# Overview

Closes #561.

What problem does this address?

* NREL Standard Scenarios data is not available for download from static links, only from a javascript-powered web app
* We reverse engineered the API calls made by the web app and reproduce them here; they're basic GET and POST requests with no credentials necessary

What did you change in this PR?

* Add options for POST to `pudl_archiver.archivers.classes._download_file()` and `pudl_archiver.archivers.classes.AbstractDatasetArchiver.download_file()`
* Split hyperlink extraction in `pudl_archiver.archivers.classes.AbstractDatasetArchiver` into two phases to permit extraction of links directly from an HTML string
* New archiver for NREL Standard Scenarios

# Testing

How did you make sure this worked? How can a reviewer verify this?

Ran locally in fsspec and checked md5s against Zenodo.

# To-do list

```[tasklist]
- [x] Confirm raw license
- [x] Actually test it locally
- [ ] ~~Add some delays between metadata fetches so we're nice to the NREL API server (or else they might add credentialing and our archiver would break)~~ 
- [x] Reduce general chaos -- pull up URLs and regex patterns, make error messages make sense, etc
- [x] Wait for #538 to merge (or maybe rebase this branch to that one)
- [x] Update documentation
- [x] Self-review
```
