### PR TITLE
Switch to a new prettier mirror and bump ruff pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,14 +26,14 @@ repos:
   # Formatters: hooks that re-write Python and RST files
   #####################################################################################
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.9.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.4.2
     hooks:
       - id: prettier
         types_or: [yaml]


### PR DESCRIPTION
# Overview

Switch to using a different mirror of the `prettier` pre-commit hook that is actually being maintained.

# Testing

I ran the `prettier` pre-commit hook on all files locally and it didn't do anything unexpected.