### PR TITLE
Make server selection on `initialize-archiver` clearer

### DIFF
--- a/.github/workflows/initialize-archiver.yml
+++ b/.github/workflows/initialize-archiver.yml
@@ -9,11 +9,13 @@ on:
         default: ""
         required: true
         type: string
-      sandbox:
-        description: "Initialize a new archive on the Zenodo sandbox server?"
-        default: true
+      server:
+        description: "Which Zenodo server would you like to run on?"
+        options:
+          - sandbox
+          - production
         required: true
-        type: boolean
+        type: choice
 
 jobs:
   archive-run:
@@ -63,7 +65,7 @@ jobs:
           EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
           ZENODO_TOKEN_UPLOAD: ${{ secrets.ZENODO_TOKEN_UPLOAD }}
           ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
-        if: ${{ inputs.sandbox == false }}
+        if: ${{ inputs.server == 'production' }}
         run: |
           pudl_archiver --datasets ${{ matrix.dataset }} --initialize --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
 
@@ -72,7 +74,7 @@ jobs:
           ZENODO_SANDBOX_TOKEN_UPLOAD: ${{ secrets.ZENODO_SANDBOX_TOKEN_UPLOAD }}
           ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
           EPACEMS_API_KEY: ${{ secrets.EPACEMS_API_KEY }}
-        if: ${{ inputs.sandbox == true }}
+        if: ${{ inputs.server == 'sandbox' }}
         run: |
           pudl_archiver --datasets ${{ matrix.dataset }} --initialize --sandbox --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
 

--- a/.github/workflows/initialize-archiver.yml
+++ b/.github/workflows/initialize-archiver.yml
@@ -11,7 +11,7 @@ on:
         type: string
       server:
         description: "Which Zenodo server would you like to run on?"
-        default: 'sandbox'
+        default: "sandbox"
         options:
           - sandbox
           - production

--- a/.github/workflows/initialize-archiver.yml
+++ b/.github/workflows/initialize-archiver.yml
@@ -11,6 +11,7 @@ on:
         type: string
       server:
         description: "Which Zenodo server would you like to run on?"
+        default: 'sandbox'
         options:
           - sandbox
           - production


### PR DESCRIPTION
# Overview

What problem does this address?
Makes the choice of server more obvious in `initialize-archiver`

What did you change in this PR?
- Switch from boolean to choice in github action

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run the action on this branch for both production and sandbox servers.
Sandbox: https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/13168342804/job/36753639628
Prod: https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/13168368880/job/36753714104

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
