### PR TITLE
smol xbrl rssfeed fix (sorted was converting rssfeed dictionary to a list)

### DIFF
--- a/src/pudl_archiver/archivers/ferc/xbrl.py
+++ b/src/pudl_archiver/archivers/ferc/xbrl.py
@@ -360,7 +360,16 @@ async def archive_year(
         # Save snapshot of RSS feed
         with archive.open("rssfeed", "w") as f:
             logger.info("Writing rss feed metadata to archive.")
-            f.write(json.dumps(sorted(metadata), default=str, indent=2).encode("utf-8"))
+            f.write(
+                json.dumps(
+                    {
+                        filing_name: metadata[filing_name]
+                        for filing_name in sorted(metadata)
+                    },
+                    default=str,
+                    indent=2,
+                ).encode("utf-8")
+            )
 
     logger.info(f"Finished scraping ferc{form_number}-{year}.")
 

--- a/tests/unit/ferc_archiver_test.py
+++ b/tests/unit/ferc_archiver_test.py
@@ -207,6 +207,13 @@ async def test_archive_year_metadata(tmpdir):
         archive.open("rssfeed") as f,
     ):
         assert (
-            json.dumps(sorted(expected_metadata), default=str, indent=2).encode()
+            json.dumps(
+                {
+                    filing_name: expected_metadata[filing_name]
+                    for filing_name in sorted(expected_metadata)
+                },
+                default=str,
+                indent=2,
+            ).encode()
             == f.read()
         )


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?
in the standard monthly archiving process ella published a new ferc1 zenodo archive today. we decided to try to integrate it into pudl to work out integration kinks even though rn it looks like ~80% of the utilities have responded. and I’ve found the first  road block, but then i think it's fixed.

it looks like in the past archives the `rssfeed` files for each year are dictionaries. in this most recent archive the `rssfeed`  is just a list of respondents. it looks like this got changed ~7 months ago w/ a small fix. But the dictionary was being `sorted` which converted this into a list of just the filer names instead of the full dictionary.

What did you change in this PR?
kept sorting the dictionary but just used `sorted` to sort all of the keys.

Questions?
- was this change intentional somehow in someway that I'm missing??
- is there anything downstream (except me trying to run the ferc1_xbrl -> sqlite conversion) that I should look out for?

# Testing

How did you make sure this worked? How can a reviewer verify this?
i ran:
`pudl_archiver --datasets ferc1`
which gave me this draft:
https://zenodo.org/uploads/15264594
and i checked several of the xbrl years and all the `rssfeed` docs are all dictionaries!

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
