### PR TITLE
Archive 2014-2018 VCE RARE data

### DIFF
--- a/src/pudl_archiver/archivers/vcerare.py
+++ b/src/pudl_archiver/archivers/vcerare.py
@@ -22,11 +22,14 @@ class VCERAREArchiver(AbstractDatasetArchiver):
 
     name = "vcerare"
     bucket_name = "sources.catalyst.coop"
+    version = "v2"  # Version of the files to archive
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download VCE RARE resources."""
         bucket = storage.Client().get_bucket(self.bucket_name)
-        blobs = bucket.list_blobs(prefix=f"{self.name}/")  # Get all blobs in folder
+        blobs = bucket.list_blobs(
+            prefix=f"{self.name}/{self.version}"
+        )  # Get all blobs in folder
 
         for blob in blobs:
             # Skip the folder, which appears in this list
@@ -40,7 +43,7 @@ class VCERAREArchiver(AbstractDatasetArchiver):
         of zipped annual files that are named vcerare_{year}.zip.
         """
         # Remove folder name (identical to dataset name) and set download path
-        file_name = blob.name.replace(f"{self.name}/", "")
+        file_name = blob.name.replace(f"{self.name}/{self.version}/", "")
         path_to_file = self.download_directory / file_name
         # Download blob to local file
         self.logger.info(f"Downloading {blob.name} to {path_to_file}")


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Archives data needed for https://github.com/catalyst-cooperative/pudl/issues/4226.

What problem does this address?
- We have new 2014-2018 VCE RARE data - we need to archive it so we can publish it in PUDL.

What did you change in this PR?
- [x] Update data in GCS bucket, creating a new version folder to avoid overwriting changes to README and other files
- [x] Update the VCE RARE archiver to be able to point at a version folder, rather than storing all files from all versions in the same folder

# Testing

How did you make sure this worked? How can a reviewer verify this?
`pudl_archiver --dataset vcerare --sandbox --summary-file vcerare.json`
See also: https://sandbox.zenodo.org/records/203310

# To-do list

```[tasklist]
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
