### PR TITLE
Ensure uploaded files match local checksums (502 mitigation)

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -79,7 +79,7 @@ jobs:
           ZENODO_TOKEN_PUBLISH: ${{ secrets.ZENODO_TOKEN_PUBLISH }}
         if: ${{ inputs.server == 'sandbox' }}
         run: |
-          pudl_archiver --datasets ${{ matrix.dataset }} --sandbox --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
+          pixi run pudl_archiver --datasets ${{ matrix.dataset }} --sandbox --summary-file ${{ matrix.dataset }}_run_summary.json --clobber-unchanged
 
       - name: Upload run summaries
         if: always()

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ This will setup and activate the environment, and install the pre-commit hooks.
 > [!TIP]
 > Instead of `pixi shell`, you can also use `pixi run` to run the archiver code in
 > the correct Python environment (e.g., `pixi run pudl_archiver --dataset eiawater`).
+>
+> If you are running integration tests locally, you'll need to use the "tests" pixi
+> environment (e.g., `pixi shell -e tests`; `pixi run -e tests pytest ...`)
 
 ## Setting up the development environment
 

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict
 
 from pudl_archiver.archivers.validate import RunSummary
 from pudl_archiver.frictionless import DataPackage, ResourceInfo
-from pudl_archiver.utils import RunSettings, Url
+from pudl_archiver.utils import RunSettings, Url, compute_md5
 
 logger = logging.getLogger(f"catalystcoop.{__name__}")
 
@@ -226,6 +226,15 @@ class DraftDeposition(BaseModel, ABC):
         ...
 
     @abstractmethod
+    def get_checksum(self, filename: str) -> str | None:
+        """Get checksum for a file in the current deposition.
+
+        Args:
+            filename: Name of file to checksum.
+        """
+        ...
+
+    @abstractmethod
     async def list_files(self) -> list[str]:
         """Return list of filenames from previous version of deposition."""
         ...
@@ -248,7 +257,7 @@ class DraftDeposition(BaseModel, ABC):
             data: the actual data associated with the file.
 
         Returns:
-            None if success.
+            DraftDeposition with the created file
         """
         ...
 
@@ -263,7 +272,7 @@ class DraftDeposition(BaseModel, ABC):
             target: the filename of the file you want to delete.
 
         Returns:
-            None if success.
+            DraftDeposition with the deleted file
         """
         ...
 
@@ -341,7 +350,6 @@ class DraftDeposition(BaseModel, ABC):
         """Actually upload and delete what we listed in self.uploads/deletes.
 
         Args:
-            draft: the draft to make these changes to
             change: the change to make
         """
         draft = self
@@ -351,9 +359,26 @@ class DraftDeposition(BaseModel, ABC):
             if change.resource is None:
                 raise RuntimeError("Must pass a resource to be uploaded.")
 
-            draft = await self._upload_file(
-                _UploadSpec(source=change.resource, dest=change.name)
-            )
+            checksum = compute_md5(change.resource)
+            for chance in range(5):
+                draft = await self._upload_file(
+                    _UploadSpec(source=change.resource, dest=change.name)
+                )
+                if (uploaded_checksum := draft.get_checksum(change.name)) == checksum:
+                    logger.info(
+                        f"Matching checksums for {change.name}: {uploaded_checksum}, {checksum}"
+                    )
+                    break
+                logger.warn(
+                    f"Upload of {change.name} failed with nonmatching checksum (try {chance + 1} of 5)"
+                )
+                # drop the bad upload before retrying
+                draft = await self.delete_file(change.name)
+            else:  # if we run out of tries
+                raise RuntimeError(
+                    f"Upload of {change.name} persistently failing; could not get checksums to match."
+                )
+
         return draft
 
     async def _upload_file(self, upload: _UploadSpec):
@@ -363,7 +388,10 @@ class DraftDeposition(BaseModel, ABC):
             with upload.source.open("rb") as f:
                 wrapped_file = FileWrapper(f.read())
 
-        draft = await self.create_file(upload.dest, wrapped_file)
+        draft = await self.create_file(
+            upload.dest,
+            wrapped_file,
+        )
 
         wrapped_file.actually_close()
         return draft

--- a/src/pudl_archiver/depositors/depositor.py
+++ b/src/pudl_archiver/depositors/depositor.py
@@ -364,12 +364,9 @@ class DraftDeposition(BaseModel, ABC):
                 draft = await self._upload_file(
                     _UploadSpec(source=change.resource, dest=change.name)
                 )
-                if (uploaded_checksum := draft.get_checksum(change.name)) == checksum:
-                    logger.info(
-                        f"Matching checksums for {change.name}: {uploaded_checksum}, {checksum}"
-                    )
+                if draft.get_checksum(change.name) == checksum:
                     break
-                logger.warn(
+                logger.warning(
                     f"Upload of {change.name} failed with nonmatching checksum (try {chance + 1} of 5)"
                 )
                 # drop the bad upload before retrying
@@ -388,10 +385,7 @@ class DraftDeposition(BaseModel, ABC):
             with upload.source.open("rb") as f:
                 wrapped_file = FileWrapper(f.read())
 
-        draft = await self.create_file(
-            upload.dest,
-            wrapped_file,
-        )
+        draft = await self.create_file(upload.dest, wrapped_file)
 
         wrapped_file.actually_close()
         return draft

--- a/src/pudl_archiver/depositors/fsspec.py
+++ b/src/pudl_archiver/depositors/fsspec.py
@@ -174,6 +174,17 @@ class FsspecDraftDeposition(DraftDeposition):
             deposition=self.deposition,
         )
 
+    def get_checksum(self, filename: str) -> str | None:
+        """Get checksum for a file in the current deposition.
+
+        Args:
+            filename: Name of file to checksum.
+        """
+        filepath = self.deposition.deposition_path / filename
+        if filepath.exists():
+            return compute_md5(filepath)
+        return None
+
     async def create_file(
         self,
         filename: str,

--- a/src/pudl_archiver/depositors/zenodo/depositor.py
+++ b/src/pudl_archiver/depositors/zenodo/depositor.py
@@ -175,7 +175,7 @@ class ZenodoAPIClient(DepositorAPIClient):
             data: the actual data associated with the file.
 
         Returns:
-            None if success.
+            Remote deposition after creating file.
         """
         if deposition.links.bucket and force_api != "files":
             url = f"{deposition.links.bucket}/{filename}"
@@ -215,7 +215,7 @@ class ZenodoAPIClient(DepositorAPIClient):
             None if success.
         """
         if not (file_to_delete := deposition.files_map.get(filename)):
-            logger.info(f"No files matched {filename}.")
+            logger.info(f"No files matched {filename}; could not delete.")
             return None
 
         await self._request(
@@ -657,7 +657,9 @@ class ZenodoDraftDeposition(DraftDeposition):
         return self.model_copy(
             update={
                 "deposition": await self.api_client.create_file(
-                    self.deposition, filename, data
+                    self.deposition,
+                    filename,
+                    data,
                 )
             }
         )
@@ -693,6 +695,15 @@ class ZenodoDraftDeposition(DraftDeposition):
             filename: Name of file to fetch.
         """
         return await self.api_client.get_file(self.deposition, filename)
+
+    def get_checksum(self, filename: str) -> str | None:
+        """Get checksum for a file in the current deposition.
+
+        Args:
+            filename: Name of file to checksum.
+        """
+        file_info = self.deposition.files_map.get(filename)
+        return file_info.checksum if file_info else None
 
     async def list_files(self) -> list[str]:
         """Return list of filenames from published version of deposition."""

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -137,21 +137,6 @@ def test_settings():
         yield Path(tmp_dir)
 
 
-class TestDownloader(AbstractDatasetArchiver):
-    name = "Test Downloader"
-
-    def __init__(self, resources, **kwargs):
-        super().__init__(**kwargs)
-        self.resources = resources
-
-    async def get_resources(self):
-        async def identity(x):
-            return x
-
-        for info in self.resources.values():
-            yield identity(info)
-
-
 @pytest.mark.asyncio
 async def test_zenodo_workflow(
     session: aiohttp.ClientSession,
@@ -203,6 +188,20 @@ async def test_zenodo_workflow(
 
             # Verify that contents of file are correct
             assert res.text.encode() == file_data["contents"]
+
+    class TestDownloader(AbstractDatasetArchiver):
+        name = "Test Downloader"
+
+        def __init__(self, resources, **kwargs):
+            super().__init__(**kwargs)
+            self.resources = resources
+
+        async def get_resources(self):
+            async def identity(x):
+                return x
+
+            for info in self.resources.values():
+                yield identity(info)
 
     # Mock out creating deposition metadata with fake data source
     deposition_metadata_mock = mocker.MagicMock(return_value=deposition_metadata)

--- a/tests/integration/zenodo_test.py
+++ b/tests/integration/zenodo_test.py
@@ -300,12 +300,12 @@ async def test_zenodo_workflow(
     # Force a mismatched checksum for all files
     with unittest.mock.patch(
         "pudl_archiver.depositors.zenodo.depositor.ZenodoDraftDeposition.get_checksum",
-        # depositor.DraftDeposition.get_checksum",
         lambda *_args: "nonsense_checksum",
     ):
         downloader = TestDownloader(vc_resources, session=session)
         downloader.fail_on_file_size_change = False
         downloader.fail_on_dataset_size_change = False
+        downloader.fail_on_missing_files = False
         with pytest.raises(RuntimeError, match=".*could not get checksums to match.*"):
             vc_summary, vc_refreshed = await orchestrate_run(
                 dataset="pudl_test",
@@ -317,8 +317,7 @@ async def test_zenodo_workflow(
     # Wait for deleted deposition to propogate through
     time.sleep(1)
 
-    # Disable test and re-run
-    downloader.fail_on_missing_files = False
+    # re-run with normal checksums
     vc_summary, vc_refreshed = await orchestrate_run(
         dataset="pudl_test",
         downloader=downloader,


### PR DESCRIPTION
# Overview

Closes #458.

_What problem does this address?_

Sometimes Zenodo returns a 502, and when that happens, sometimes the file Zenodo keeps is incomplete.

_What did you change in this PR?_

* Add code to `DraftDeposition._apply_change` that verifies the checksum of the uploaded file matches the checksum of the local file. If not, retry up to 5 times before raising an exception.
* Add abstract method `get_checksum` to `DraftDeposition`, and implementations in the zenodo and fsspec subclasses (this helps us avoid having to pass the reference checksum through a bunch of nested functions)
* Add integration test to verify intended behavior in the event of a nonmatching remote checksum
* Update misleading docstrings discovered during the quest

# Feedback requests

Specifically hoping for input on:
- [x] Is raising an exception the right way to go here, or do we need something gentler?
- [x] Number of retries is currently hard-coded; keep it that way y/n?
- [x] The integration test `test_zenodo_workflow` is borderline-unwieldy; I started pulling it apart a bit but got tangled and backed most of it out. Is a refactor there something we should consider as a followup, or is it fine?

# Testing

_How did you make sure this worked? How can a reviewer verify this?_

- [x] Integration test
- [ ] Run in GHA in sandbox 

# To-do list

- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

