### PR TITLE
Use pixi run to run unit test pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         verbose: false
         pass_filenames: false
         always_run: true
-        entry: pytest tests/unit
+        entry: pixi run pytest tests/unit
 
 # Configuration for pre-commit.ci
 ci:


### PR DESCRIPTION
# Overview

Prefix our local unit test pre-commit hook with `pixi run` so that it Just Works.

Closes #694 

# Testing

It seemed to work when I made the commit for this PR!