### PR TITLE
Grab multiple versions of NREL ATB data

### DIFF
--- a/src/pudl_archiver/archivers/nrel/nrelatb.py
+++ b/src/pudl_archiver/archivers/nrel/nrelatb.py
@@ -201,7 +201,7 @@ class NrelAtbArchiver(AbstractDatasetArchiver):
 
         # The default base url to grab the excel files contains some of the
         # data (the link to the CSVs and the most recent versions)
-        # For older versions of the data, we also want to grab files from the OpenEI
+        # For newer versions of the data, we also want to grab files from the OpenEI
         # page linked on the page (if it exists, after 2022 and only for electricity).
         # This includes prior versions of Excel and Tableau worksheets.
         if year > 2022:


### PR DESCRIPTION
# Overview

Closes #704 

What problem does this address?
We now have multiple versions of NREL ATB Parquet data, CSV data, and workbook data. Each is stored in a different place:
- Parquet in the S3 data viewer, with versioned data published for 2024 only
- CSV in the S3 data viewer, with versioned data published for 2024 only
- Other workbook data published both on the main data page and in the OEDI data page for each site, with the older versions only available in the OEDI site.

Most immediately, the addition of more than one version to the Parquet bucket was breaking the archiver's regex patterns. With the addition of multiple versions of data, we want to switch to consistently grabbing everything for all data sources.

What did you change in this PR?
This PR makes it possible to grab all versions of datasets, adding all versions to the year zips. To do this, we:

- Add the version to the file name where it exists
- Add both versions of each file to the same zipfile
- Add CSV grabbing directly from the S3 data viewer by generalizing the existing Parquet methods. This enables us to grab more than one version of CSVs if published, as they only link to the latest version on the main data page.
- Ad grabbing the data from the corresponding [OEDI page](https://data.openei.org/submissions/6006) where it exists in addition to the main data page, which would download all versions of all files. This is already implemented for data pages prior to 2022, with the manual URL mapping in `year_to_excel_url`.
- Make grabbing the OEDI page from the main page automated for the newer data sources, rather than requiring manual mapping as is done in `year_to_excel_url`

# Questions for the reviewer
- Transportation data (only) provides a zipped CSV on the main datapage, so we have now each individual CSV file and a zipfile containing theoretically the same data. Should I skip CSV downloads for the transport data/should we trust that NREL has the same data in both formats? Or should we err on the side of duplication.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Testing:

[Old zips](https://zenodo.org/records/15166076):

Only in 15166076/nrelatb-2024-electricity: nrelatb-2024-electricity-atbe.csv
Only in 15166076/nrelatb-2024-electricity: nrelatb-2024-electricity-atbe.parquet
(replaced by versioned csv and parquet versions)

Only in 15166076/nrelatb-2024-transportation: nrelatb-2024-transportation-atb-and-lit-redacted.parquet
(renamed to remove `atb` when using shared file name cleaner)

[New zips](https://sandbox.zenodo.org/records/277083):

Only in 277083/nrelatb-2019-electricity: nrelatb-2019-electricity-atbe.csv
Only in 277083/nrelatb-2020-electricity: nrelatb-2020-electricity-atbe.csv
Only in 277083/nrelatb-2021-electricity: nrelatb-2021-electricity-atbe.csv
Only in 277083/nrelatb-2022-electricity: nrelatb-2022-electricity-atbe.csv
Only in 277083/nrelatb-2022-transportation: nrelatb-2022-transportation-fuels.csv
Only in 277083/nrelatb-2022-transportation: nrelatb-2022-transportation-fuels-marine.csv
Only in 277083/nrelatb-2022-transportation: nrelatb-2022-transportation-vehicles.csv
Only in 277083/nrelatb-2022-transportation: nrelatb-2022-transportation-vehicles-fuels.csv
Only in 277083/nrelatb-2023-electricity: nrelatb-2023-electricity-atbe.csv
Only in 277083/nrelatb-2023-electricity: nrelatb-2023-electricity-v1-model-parameters-original-6-28-2022.csv.csv
Only in 277083/nrelatb-2023-electricity: nrelatb-2023-electricity-v1-tableau-workbooks-original-6-28-2023.zip
Only in 277083/nrelatb-2023-electricity: nrelatb-2023-electricity-v1-workbook-original-6-28--1.xlsx
Only in 277083/nrelatb-2023-electricity: nrelatb-2023-electricity-v2-tableau-workbooks-07-20-23.zip
Only in 277083/nrelatb-2023-electricity: nrelatb-2023-electricity-v2-workbook-07-20-23.xlsx
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v1-model-parameters-original-6-24-2024.csv
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v1-tableau-workbooks-06-24-24.zip
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v1-workbook-original-6-24-2024.xlsx
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v2-0-0-atbe.csv
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v2-0-0-atbe.parquet
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v2-tableau-workbooks-07-19-24.zip
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v2-workbook-errata-7-19-2024.xlsx
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v3-0-0-atbe.csv
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v3-0-0-atbe.parquet
Only in 277083/nrelatb-2024-electricity: nrelatb-2024-electricity-v3-model-parameters.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-and-lit-redacted.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-and-lit-redacted.parquet
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-aviation.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-aviation-emissions.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-blend-ratios.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-charger-efficiency.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-discount-rate.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-distribution-and-taxes.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-emissions.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-emissions-h2-delivery.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-emissions-h2-onroad.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-emissions-h2-production.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-fuel-prices.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-fuels.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-inputs-fuels-prices-elec.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-inputs-fuels-prices-h2.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-inputs-vehicles.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-jet-data.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-lhv.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-maintenance-mdhd.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-marine-emissions.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-phev-uf-ldv.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-phev-uf-mdhd.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-tea.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-vehicle-lifetime.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-vehicles.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-vehicles-fuels.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-vmt-ldv.csv
Only in 277083/nrelatb-2024-transportation: nrelatb-2024-transportation-vmt-mdhd.csv

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
