### PR TITLE
Fix cron job clashes in `run-archiver`

### DIFF
--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -23,8 +23,8 @@ on:
         required: true
         type: boolean
   schedule:
-    - cron: "21 8 2-31 6-7,9-10 0,2-6"
-    # 8:21 AM UTC, every day in June, July, Sept, Oct.
+    - cron: "21 9 2-31 6-7,9-10 0,2-6"
+    # 9:21 AM UTC, every day in June, July, Sept, Oct.
     # Don't run on Mondays or the 1st of the month, when run-archiver.yml runs
 
 jobs:

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -23,8 +23,7 @@ on:
         required: true
         type: boolean
   schedule:
-    - cron: "21 8 1 * *" # 8:21 AM UTC, first of every month
-    - cron: "21 8 * * 1" # 8:21 AM UTC, every Monday
+    - cron: "21 8 1 * 1" # 8:21 AM UTC, first of every month and every Monday
 
 jobs:
   archive-run:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?
Sometimes the first of the month is a Monday. Which means that both cron schedules on the `run-archiver` GHA execute at the same time, causing a bunch of conflicts and failures as Zenodo tries to process two different versions at once ([run #1](https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/17372156165), [run #2](https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/17372190087)).

What did you change in this PR?
The [manpage for crontab](https://www.man7.org/linux/man-pages/man5/crontab.5.html) helpfully lets us know that day of week and day of month are processed as an OR condition - either Monday or the 1st of the month. This means we can reduce 2 cron expressions that execute separately to one that will meet both our conditions.

While we're at it, I also bump the early_release_checker.yml cron job forward by an hour to avoid similar problems occurring.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See this [crontab](https://crontab.guru/#21_8_1_*_1) checker as one example.

# To-do list

- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

