### PR TITLE
Fix ferc2 partitions

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferc2.py
+++ b/src/pudl_archiver/archivers/ferc/ferc2.py
@@ -85,7 +85,7 @@ class Ferc2Archiver(AbstractDatasetArchiver):
             download_path = self.download_directory / f"ferc2-{year}-{part}.zip"
         else:
             assert year >= 1996 and year <= 2021  # nosec: B101
-            partitions = {"part": "monolithic"}
+            partitions = {"part": "all"}
             url = f"https://forms.ferc.gov/f2allyears/f2_{year}.zip"
             download_path = self.download_directory / f"ferc2-{year}.zip"
 


### PR DESCRIPTION
# Overview

When attempting to use new FERC doi's, @e-belfer discovered an issue that seems to stem from FERC2 partition key/values. In #731 I made a change to how DBF partitions are set to remove the `part` key from years that have a monolithic DBF file. However, the PUDL `Datastore` thinks there are duplicate resources for 1996-1999 where we have both monolithic and split DBF files. To avoid this we can add the `part` key back in, but rather than the value defaulting to `None`, it will now have a value. This should also avoid the issue where `part=None` was causing the archiver to incorrectly think something changed when it didn't.