### PR TITLE
Don't run early final release checker on sundays

### DIFF
--- a/.github/workflows/early_final_release_checker.yml
+++ b/.github/workflows/early_final_release_checker.yml
@@ -25,7 +25,7 @@ on:
   schedule:
     - cron: "21 9 2-31 6-7,9-10 1-6"
     # 9:21 AM UTC, every day in June, July, Sept, Oct.
-    # Don't run on Mondays or the 1st of the month, when run-archiver.yml runs
+    # Don't run on Sundays or the 1st of the month, when run-archiver.yml runs
 
 jobs:
   archive-run:


### PR DESCRIPTION
# Overview

* Update final release checker to avoid Sundays so it doesn't collide with the primary archiver run.
* Also addressed some suggestions from `shellcheck` which came up from the github action workflow linter.

Closes #897

