### PR TITLE
Add EPA/CAMD-EIA year 2024

### DIFF
--- a/src/pudl_archiver/archivers/epa/epacamd_eia.py
+++ b/src/pudl_archiver/archivers/epa/epacamd_eia.py
@@ -21,7 +21,7 @@ class EpaCamdEiaArchiver(AbstractDatasetArchiver):
         simplest solution is to use the 2018 data from the EPA repo and the latest data
         from our fork as static outputs. At some point it would be best to either
         integrate the notebook into our ETL so we can dynamically run it with all years
-        interest, or develop our own linkage.
+        of interest, or develop our own linkage.
         """
         yield self.get_2018()
         yield self.get_latest_years()
@@ -29,7 +29,7 @@ class EpaCamdEiaArchiver(AbstractDatasetArchiver):
     async def get_latest_years(self) -> ResourceInfo:
         """Get latest version from our forked repo."""
         resources = []
-        for year in [2019, 2020, 2021, 2022, 2023]:
+        for year in [2019, 2020, 2021, 2022, 2023, 2024]:
             url = f"https://github.com/catalyst-cooperative/camd-eia-crosswalk-latest/archive/refs/tags/v{year}.zip"
             download_path = self.download_directory / f"epacamd_eia_{year}.zip"
             await self.download_zipfile(url, download_path)


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Prerequisite for integrating 2024 annual update of the EPA/CAMD-EIA crosswalk into PUDL.

What did you change in this PR?

- Add 2024 to the year-tags fetched by the archiver

# Testing

How did you make sure this worked? How can a reviewer verify this?

- [x] Ran locally and examined results
- [x] Ran in GHA as draft and examined results

# To-do list

- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

