### PR TITLE
Install pixified PUDL

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11495,7 +11495,7 @@ packages:
 - pypi: ./
   name: pudl-archiver
   version: 0.2.0
-  sha256: 8160666793d4996e57e50f012ab6f891f4d1c7acd4912af3f8c86add9304bc80
+  sha256: 8cd6ec5f6ddae789afbf6627376cc45a333826a5cc551472748ec5f5de9a8ad9
   requires_python: '>=3.13'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-20.0.0-py313h78bf25f_0.conda
   sha256: 61b27da2d9512f2c0ddad4a86725fa1d04f482b6bad374f3535d8bf21ea4b84e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,10 @@ pytest \
     tests/integration
 """, description = "Run integration tests with coverage" }
 coverage = { cmd = "coverage report --sort=cover", description = "Report test coverage" }
-lint = { depends-on = ["ruff", "pre-commit"], description = "Run all linters" }
+lint = { depends-on = [
+  "ruff",
+  "pre-commit-run",
+], description = "Run all linters" }
 ci = { depends-on = [
   "lint",
   "unit",
@@ -212,6 +215,7 @@ sphinx-autoapi = ">=3.6.1,<4"
 sphinx-issues = ">=5.0.1,<6"
 tqdm = ">=4.67.1,<5"
 types-requests = ">=2.32.4.20250913,<3"
+pyproj = "*"
 
 [tool.pixi.activation]
 scripts = ["scripts/check_playwright_installation.sh"]


### PR DESCRIPTION
# Overview

Temporarily install PUDL from the `setup-pixi` branch while making changes to `pyproject.toml` here to get things working together.

## Incidental changes

Off topic but I updated a few things in the `pyproject.toml` based on my experience setting up the new configuration with pixi in PUDL.

- Moved most `pudl-archiver` dependencies into the `tool.pixi.dependencies` section so they install from `conda-forge` rather than PyPI.
- Added `PIXI_LOCKED` to the activation environment so it's using the existing `pixi.lock` rather than resolving every time `pixi run` or `pixi install` is invoked.
- Switched to using native TOML table `[tool.pytest]` instead of legacy `[tool.pytest.ini_options]`
- Switched build backend from `setuptools` to `hatchling`.
- Removed `project.classifiers` since they are only used when publishing to PyPI.

## Questions / Notes

- When `playwright` is installed from `conda-forge` it can't be imported, but if it comes from `pypi` then it's fine. I suspect this has to do with how the playwright activation script works. The most recent version of playwright is available on `conda-forge` so it seems like we should be able to figure this out.
- There's apparently no way to use the dynamic version from `hatch-vcs` in the pixi packaging, so PUDL will always show up with a fake `v0.0.0` version.
- 

# Testing

- The CI passes!
- I was able to `pixi update` locally and then `pixi run ci` and it all worked.
- Installing the PUDL conda package both from git and from a local path to the pudl repo works. (this will probably be convenient for development work when there are changes to coordinate)

# To-do list

- [x] After https://github.com/catalyst-cooperative/pudl/pull/4871 has been merged, update the git URL to point at `main`