### PR TITLE
Remove gdal exclusion from pixi upgrade b/c no gdal.

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Update lockfiles and install
         run: |
           set -o pipefail
-          pixi upgrade --json --exclude gdal | pixi exec pixi-diff-to-markdown >> diff.md
+          pixi upgrade --json | pixi exec pixi-diff-to-markdown >> diff.md
           pixi reinstall --all
       - name: Generate GH token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
# Overview

- The weekly lockfile update previously had to exclude `gdal` since it needed to be kept the same as whatever was in the PUDL repo, but that's no longer necessary because it's installed as a transitive dependency now, so I removed it.
- I also wanted to test that the `update-lockfiles` workflow still worked, given the rearrangement of dependencies in `pyproject.toml`.
- Other dependencies with upper pins in the PUDL repo like `pyarrow` also seem to have the upper pin coming through in the update, which is great.

# Testing

- Did a manual run of `update-lockfiles` and it seemed to work.  I did not merge it.