### PR TITLE
Add partitions to `ferccid` archiver

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferccid.py
+++ b/src/pudl_archiver/archivers/ferc/ferccid.py
@@ -30,7 +30,9 @@ class FercCIDArchiver(AbstractDatasetArchiver):
         month = last_updated.month
         day = last_updated.day
         if self.valid_year(year):
-            dataset_path = self.download_directory / f"ferccid-{year}-{month}-{day}.csv"
+            dataset_path = (
+                self.download_directory / f"ferccid-data-table-{year}-{month}-{day}.csv"
+            )
             data_dictionary_path = (
                 self.download_directory
                 / f"ferccid-data-dictionary-{year}-{month}-{day}.csv"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Adds `data_set` partitions to the FERC CID archiver to differentiate between the data dictionary and the data table. The accompanying PUDL metadata update PR is [here](https://github.com/catalyst-cooperative/pudl/pull/4968).

What problem does this address?

During the extraction process of the FERC CID table, I got to the point where the data store needed partitions in order to know which of the files (data table vs data dictionary) to download. 

What did you change in this PR?

This PR adds partitions to differentiate between the CSVs, and renames the data table to include "data-table" in the name (in line with the partitions). I was following the partition naming convention used in the EIA API metadata and archive.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Once the PUDL metadata PR is merged, I will test this by running the archiver GH action.

# To-do list

- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

