### PR TITLE
Add `fsspec` publication workflow

### DIFF
--- a/.github/workflows/publish-fsspec-archive.yml
+++ b/.github/workflows/publish-fsspec-archive.yml
@@ -40,11 +40,6 @@ jobs:
           pixi info
           pixi list
 
-      - name: Additional Playwright setup
-        run: |
-          pixi run playwright install --with-deps webkit
-          pixi run playwright install --with-deps chromium
-
       - name: Download run summary
         uses: actions/download-artifact@v8
         with:
@@ -59,6 +54,5 @@ jobs:
           set -o pipefail
           pixi run pudl_archiver \
             archive \
-            retry-run \
-            --auto-publish \
+            publish-run \
             ${{ inputs.dataset }}_run_summary.json 2>&1 | tee ${{ inputs.dataset }}_log.txt

--- a/.github/workflows/publish-fsspec-archive.yml
+++ b/.github/workflows/publish-fsspec-archive.yml
@@ -42,6 +42,13 @@ jobs:
           pixi run playwright install --with-deps webkit
           pixi run playwright install --with-deps chromium
 
+      - name: Download run summary
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.run_id }}
+          pattern: run-summaries-${{ inputs.dataset }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Attempt to publish deposition for ${{ inputs.dataset }}
         # set -o pipefail passes on any failure codes to the next step,
         # enabling us to see whether or not the pudl_archiver run failed.
@@ -51,11 +58,4 @@ jobs:
             archive \
             retry-run \
             --auto-publish \
-            2>&1 | tee ${{ inputs.dataset }}_log.txt
-
-      - name: Download run summary
-        uses: actions/download-artifact@v8
-        with:
-          run-id: ${{ inputs.run_id }}
-          pattern: run-summaries-${{ inputs.dataset }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+            ${{ inputs.dataset }}_run_summary.json 2>&1 | tee ${{ inputs.dataset }}_log.txt

--- a/.github/workflows/publish-fsspec-archive.yml
+++ b/.github/workflows/publish-fsspec-archive.yml
@@ -1,0 +1,61 @@
+---
+name: publish-fsspec-archive
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Run ID pointing to run of run-fsspec-archiver action
+        required: true
+        type: string
+      dataset:
+        description: Name of dataset to publish from previous archive
+        required: true
+        type: string
+
+jobs:
+  publish-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set default GCP credentials
+        id: gcloud-auth
+        continue-on-error: true
+        uses: "google-github-actions/auth@v3"
+        with:
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "pudl-archiver-gha@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          cache: true
+
+      - name: Log the pixi environment
+        run: |
+          pixi info
+          pixi list
+
+      - name: Additional Playwright setup
+        run: |
+          pixi run playwright install --with-deps webkit
+          pixi run playwright install --with-deps chromium
+
+      - name: Attempt to publish deposition for ${{ inputs.dataset }}
+        # set -o pipefail passes on any failure codes to the next step,
+        # enabling us to see whether or not the pudl_archiver run failed.
+        run: |
+          set -o pipefail
+          pixi run pudl_archiver \
+            archive \
+            retry-run \
+            --auto-publish \
+            2>&1 | tee ${{ inputs.dataset }}_log.txt
+
+      - name: Download run summary
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.run_id }}
+          pattern: run-summaries-${{ inputs.dataset }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-fsspec-archive.yml
+++ b/.github/workflows/publish-fsspec-archive.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   publish-run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish-fsspec-archive.yml
+++ b/.github/workflows/publish-fsspec-archive.yml
@@ -53,6 +53,5 @@ jobs:
         run: |
           set -o pipefail
           pixi run pudl_archiver \
-            archive \
             publish-run \
             ${{ inputs.dataset }}_run_summary.json 2>&1 | tee ${{ inputs.dataset }}_log.txt

--- a/.github/workflows/publish-fsspec-archive.yml
+++ b/.github/workflows/publish-fsspec-archive.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: Run ID pointing to run of run-fsspec-archiver action
+        description: Github action run ID, which is the number at the end of the URL when looking at a run
         required: true
         type: string
       dataset:
-        description: Name of dataset to publish from previous archive
+        description: Name of dataset to publish from previous archiver run
         required: true
         type: string
 

--- a/.github/workflows/run-fsspec-archiver.yml
+++ b/.github/workflows/run-fsspec-archiver.yml
@@ -73,7 +73,6 @@ jobs:
             fsspec \
             ${{ matrix.dataset }} \
             $DEPOSITION_PATH/${{ matrix.dataset }} \
-            --auto-publish \
             --clobber-unchanged 2>&1 | tee ${{ matrix.dataset }}_log.txt
 
       - name: Save failed runs

--- a/README.md
+++ b/README.md
@@ -143,12 +143,11 @@ successfully added to the archive in the previous run. Basic usage looks like th
 following:
 
 ```bash
-pudl_archiver retry-run {run_summary_json_file}
+pudl_archiver archive retry-run {run_summary_json_file}
 ```
 
 This command will inherit all settings from the previous run except `--auto-publish` to
-avoid accidental publication. This also allows `retry-run` to be used to publish results
-from a successful run which did not have `--auto-publish` set.
+avoid accidental publication.
 
 During a retry, the archiver expects all successfully downloaded resources to still
 be in the draft deposition. If the state of the deposition has been changed in any
@@ -162,6 +161,18 @@ and CLI settings.
 3. Start downloading failed resources and adding new versions to the open draft deposition.
 4. Attempt to publish draft containing resources from original run and retry, following
 standard validation procedures.
+
+### Publishing a Successful Run
+There is also a command for publishing a successful run that did not have `auto-publish`
+set. This is meant primarily for the `fsspec` archiver since Zenodo provides an
+interface for publishing drafts. This command works almost exactly like the `retry-run`
+command, but it will always have `auto-publish` set to `True`.
+
+Example usage:
+
+```bash
+pudl_archiver archive publish-run {run_summary_json_file}
+```
 
 ## Adding a new dataset
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ successfully added to the archive in the previous run. Basic usage looks like th
 following:
 
 ```bash
-pudl_archiver archive retry-run {run_summary_json_file}
+pudl_archiver retry-run {run_summary_json_file}
 ```
 
 This command will inherit all settings from the previous run except `--auto-publish` to
@@ -171,7 +171,7 @@ command, but it will always have `auto-publish` set to `True`.
 Example usage:
 
 ```bash
-pudl_archiver archive publish-run {run_summary_json_file}
+pudl_archiver publish-run {run_summary_json_file}
 ```
 
 ## Adding a new dataset

--- a/src/pudl_archiver/archivers/validate.py
+++ b/src/pudl_archiver/archivers/validate.py
@@ -1,5 +1,6 @@
 """Defines models used for validating/summarizing an archiver run."""
 
+import json
 import logging
 import re
 import xml.etree.ElementTree as Et  # nosec: B405
@@ -193,6 +194,35 @@ class RunSummary(BaseModel):
             failed_partitions=failed_partitions,
             successful_partitions=successful_partitions,
             run_settings=run_settings,
+        )
+
+    @classmethod
+    def load_previous_run(
+        cls, summary_file: str | Path, auto_publish: bool
+    ) -> "RunSummary":
+        """Create a RunSummary object from a JSON file output by a previous run.
+
+        Load settings from summary file, but always override ``auto_publish``
+        to avoid accidental publication.
+
+        Args:
+            summary_file: Points to JSON file containing serialized RunSummary metadata.
+            auto_publish: Explicitly set ``auto_publish``.
+        """
+        # Load run summary file and parse
+        with Path(summary_file).open() as f:
+            previous_run_summary = RunSummary.model_validate(json.load(f))
+
+        # Extract settings from failed run
+        return previous_run_summary.model_copy(
+            update={
+                "run_settings": previous_run_summary.run_settings.model_copy(
+                    update={
+                        "retry_run": summary_file,
+                        "auto_publish": True,
+                    },
+                )
+            }
         )
 
 

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -154,7 +154,6 @@ def fsspec(
 
 
 @archive.command
-@auto_publish_option
 @click.argument(
     "summary-file",
     type=str,

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -159,12 +159,59 @@ def fsspec(
     "summary-file",
     type=str,
 )
+def publish_run(summary_file: str):
+    """Publish the results from a successful run that did not have ``auto-publish`` set.
+
+    SUMMARY_FILE Points to a Run Summary JSON file output by a previous run which
+    which completed succesfully, but didn't publish its results. All run settings will
+    be inherited from the previous run except for ``auto-publish``, which will be
+    set to ``True``.
+    """
+    # Load run summary file and parse
+    with Path(summary_file).open() as f:
+        previous_run_summary = RunSummary.model_validate(json.load(f))
+
+    # Extract settings from failed run
+    run_settings = previous_run_summary.run_settings.model_copy(
+        update={
+            "retry_run": summary_file,
+            "auto_publish": True,
+        },
+    )
+
+    # Find which partitions failed/succeeded in previous run
+    failed_partitions = previous_run_summary.failed_partitions
+    successful_partitions = previous_run_summary.successful_partitions
+
+    if failed_partitions != {}:
+        raise RuntimeError(
+            "publish-run should not be called on a run with failed partitions."
+            "Instead, use the retry-run command."
+            f"Found the following failed partitions: {failed_partitions.keys()}"
+        )
+
+    # Retry archiver run
+    asyncio.run(
+        archive_dataset(
+            dataset=previous_run_summary.dataset_name,
+            run_settings=run_settings,
+            failed_partitions=failed_partitions,
+            successful_partitions=successful_partitions,
+        )
+    )
+
+
+@archive.command
+@auto_publish_option
+@click.argument(
+    "summary-file",
+    type=str,
+)
 def retry_run(summary_file: str, auto_publish: bool):
     """Retry a previous run of the archiver by passing a JSON summary file from the run.
 
     SUMMARY_FILE Points to a Run Summary JSON file output by a previous run which
-    either failed, or which completed succesfully, but didn't publish its results.
-    All run settings will be inherited from the previous run except for ``auto-publish``,
+    failed. All run settings will be inherited from the previous run except for ``auto-publish``,
     which will be overridden by this CLI to avoid accidental publication on a retry.
     ``auto-publish`` defaults to False in all cases.
     """
@@ -183,6 +230,12 @@ def retry_run(summary_file: str, auto_publish: bool):
     # Find which partitions failed/succeeded in previous run
     failed_partitions = failed_run_summary.failed_partitions
     successful_partitions = failed_run_summary.successful_partitions
+
+    if failed_partitions == {}:
+        raise RuntimeError(
+            "retry-run should not be called on a run with no failed partitions."
+            "Instead, use the publish-run command."
+        )
 
     # Retry archiver run
     asyncio.run(

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -161,7 +161,7 @@ def fsspec(
 def publish_run(summary_file: str):
     """Publish the results from a successful run that did not have ``auto-publish`` set.
 
-   Args:
+    Args:
          summary_file: A string pointing to a Run Summary JSON file output by a previous run which
     which completed succesfully, but didn't publish its results. All run settings will
     be inherited from the previous run except for ``auto-publish``, which will be

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -161,7 +161,8 @@ def fsspec(
 def publish_run(summary_file: str):
     """Publish the results from a successful run that did not have ``auto-publish`` set.
 
-    SUMMARY_FILE Points to a Run Summary JSON file output by a previous run which
+   Args:
+         summary_file: A string pointing to a Run Summary JSON file output by a previous run which
     which completed succesfully, but didn't publish its results. All run settings will
     be inherited from the previous run except for ``auto-publish``, which will be
     set to ``True``.

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -153,7 +153,7 @@ def fsspec(
     )
 
 
-@archive.command
+@pudl_archiver.command
 @click.argument(
     "summary-file",
     type=str,
@@ -200,7 +200,7 @@ def publish_run(summary_file: str):
     )
 
 
-@archive.command
+@pudl_archiver.command
 @auto_publish_option
 @click.argument(
     "summary-file",

--- a/src/pudl_archiver/cli.py
+++ b/src/pudl_archiver/cli.py
@@ -1,9 +1,7 @@
 """A script for archiving raw PUDL data on Zenodo."""
 
 import asyncio
-import json
 import logging
-from pathlib import Path
 
 import click
 import coloredlogs
@@ -167,16 +165,9 @@ def publish_run(summary_file: str):
     be inherited from the previous run except for ``auto-publish``, which will be
     set to ``True``.
     """
-    # Load run summary file and parse
-    with Path(summary_file).open() as f:
-        previous_run_summary = RunSummary.model_validate(json.load(f))
-
-    # Extract settings from failed run
-    run_settings = previous_run_summary.run_settings.model_copy(
-        update={
-            "retry_run": summary_file,
-            "auto_publish": True,
-        },
+    # Load run summary from successful run
+    previous_run_summary = RunSummary.load_previous_run(
+        summary_file=summary_file, auto_publish=True
     )
 
     # Find which partitions failed/succeeded in previous run
@@ -190,11 +181,13 @@ def publish_run(summary_file: str):
             f"Found the following failed partitions: {failed_partitions.keys()}"
         )
 
-    # Retry archiver run
+    # Run the archiver with settings from previous run
+    # Given that failed_partitions is empty, this will only attempt to
+    # publish the outputs of the previous run Publication is still subject to archive validation rules
     asyncio.run(
         archive_dataset(
             dataset=previous_run_summary.dataset_name,
-            run_settings=run_settings,
+            run_settings=previous_run_summary.run_settings,
             failed_partitions=failed_partitions,
             successful_partitions=successful_partitions,
         )
@@ -215,16 +208,9 @@ def retry_run(summary_file: str, auto_publish: bool):
     which will be overridden by this CLI to avoid accidental publication on a retry.
     ``auto-publish`` defaults to False in all cases.
     """
-    # Load run summary file and parse
-    with Path(summary_file).open() as f:
-        failed_run_summary = RunSummary.model_validate(json.load(f))
-
-    # Extract settings from failed run
-    run_settings = failed_run_summary.run_settings.model_copy(
-        update={
-            "retry_run": summary_file,
-            "auto_publish": auto_publish,
-        },
+    # Load run summary from failed run
+    failed_run_summary = RunSummary.load_previous_run(
+        summary_file=summary_file, auto_publish=auto_publish
     )
 
     # Find which partitions failed/succeeded in previous run
@@ -237,11 +223,12 @@ def retry_run(summary_file: str, auto_publish: bool):
             "Instead, use the publish-run command."
         )
 
-    # Retry archiver run
+    # Run the archiver with settings from previous run
+    # Given that failed partitions is not empty this will retry these partitions
     asyncio.run(
         archive_dataset(
             dataset=failed_run_summary.dataset_name,
-            run_settings=run_settings,
+            run_settings=failed_run_summary.run_settings,
             failed_partitions=failed_partitions,
             successful_partitions=successful_partitions,
         )


### PR DESCRIPTION
# Overview

This PR adds a workflow for publishing `fsspec` archives. It also modifies the `run-fsspec-archiver` to turn off auto-publish, so we can enable a review process like we have for zenodo backed archives. Now, after `run-fsspec-archiver` is complete, and new or updated data will be left in the `{ARCHIVE_BASE_DIRECTORY}/workspace` where the changes can be inspected. Once the inspection is complete, we can run `publish-fsspec-archive` with the run ID from the first workflow to publish the results.