### PR TITLE
Disable sec10k archiver from automated archives

### DIFF
--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       datasets:
         description: 'Comma-separated list of datasets to archive (e.g., "ferc2","ferc6").'
-        default: '"censuspep","doeiraec","doelead","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiacbecs","eiamecs","eianems","eiarecs","eiasteo","eiawater","epacamd_eia","epacems","epaegrid","epamats","epapcap","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","nrelsiting","nrelss","nrelsts","phmsagas","sec10k","usgsuspvdb","usgsuswtdb","vcerare"'
+        default: '"censuspep","doeiraec","doelead","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiacbecs","eiamecs","eianems","eiarecs","eiasteo","eiawater","epacamd_eia","epacems","epaegrid","epamats","epapcap","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","nrelsiting","nrelss","nrelsts","phmsagas","usgsuspvdb","usgsuswtdb","vcerare"'
         required: true
         type: string
       server:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         # Note that we can't pass global env variables to the matrix, so we manually reproduce the list of datasets here.
-        dataset: ${{ fromJSON(format('[{0}]', inputs.datasets || '"censuspep","doeiraec","doelead","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiacbecs","eiamecs","eianems","eiarecs","eiasteo","eiawater","epacamd_eia","epacems","epaegrid","epamats","epapcap","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","nrelsiting","nrelss","nrelsts","phmsagas","sec10k","usgsuspvdb","usgsuswtdb","vcerare"' )) }}
+        dataset: ${{ fromJSON(format('[{0}]', inputs.datasets || '"censuspep","doeiraec","doelead","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiacbecs","eiamecs","eianems","eiarecs","eiasteo","eiawater","epacamd_eia","epacems","epaegrid","epamats","epapcap","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","nrelsiting","nrelss","nrelsts","phmsagas","usgsuspvdb","usgsuswtdb","vcerare"' )) }}
       fail-fast: false
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Overview

This PR removes `sec10k` archiver from the `run-archiver` workflow. This archiver has had persistent issues when running in github actions, which stem from an upstream dependency, but this data is not being updated right now anyway, and I do not think it's worth the time to try to get this working. This archiver is not actually used to archive raw `sec10k` filings, but rather it archives the outputs from the extraction process, which then get pulled into PUDL. The current plan when we get back to working with `sec10k` data is to move the extraction pipeline into the PUDL repo, which would make this archiver completely unnecessary.