### PR TITLE
Handle nesting in new CAMD bulkfile response

### DIFF
--- a/src/pudl_archiver/archivers/epa/epacems.py
+++ b/src/pudl_archiver/archivers/epa/epacems.py
@@ -83,7 +83,7 @@ class EpaCemsArchiver(AbstractDatasetArchiver):
             )
         resjson = file_list.content.decode("utf8").replace("'", '"')
         file_list.close()  # Close connection.
-        bulk_files = self.__filter_for_complete_metadata(json.loads(resjson))
+        bulk_files = self.__filter_for_complete_metadata(json.loads(resjson)["items"])
         quarterly_emissions_files = [
             file
             for file in bulk_files

--- a/src/pudl_archiver/archivers/epa/epamats.py
+++ b/src/pudl_archiver/archivers/epa/epamats.py
@@ -50,7 +50,7 @@ class EpaMatsArchiver(AbstractDatasetArchiver):
             )
         resjson = file_list.content.decode("utf8").replace("'", '"')
         file_list.close()  # Close connection.
-        bulk_files = self.__filter_for_complete_metadata(json.loads(resjson))
+        bulk_files = self.__filter_for_complete_metadata(json.loads(resjson)["items"])
         quarterly_emissions_files = [
             file
             for file in bulk_files


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #1072 

What problem does this address?
Handles nesting of list of responses under new "items" dictionary key.

What did you change in this PR?
Updated both archivers to open the "items" key in the JSON dictionary response, rather than read in the dictionary directly.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run the archivers on this branch: https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/24472589460/job/71516562761

# To-do list

- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

