### PR TITLE
Fix button pointers for FERC CID archiver

### DIFF
--- a/scripts/make_markdown_notification.py
+++ b/scripts/make_markdown_notification.py
@@ -113,8 +113,11 @@ def _format_summary(
 ) -> str | None:
     name = summary["dataset_name"]
     url = summary["record_url"]
-    if any(not test["success"] for test in summary["validation_tests"]):
-        return None  # Don't report on file changes if any test failed.
+    if any(
+        (not test["success"] and test["required_for_run_success"])
+        for test in summary["validation_tests"]
+    ):
+        return None  # Don't report on file changes if any test failed that was required for the run to succeed.
 
     if file_changes := summary["file_changes"]:
         file_change_table = pd.DataFrame.from_records(file_changes)

--- a/src/pudl_archiver/archivers/ferc/ferccid.py
+++ b/src/pudl_archiver/archivers/ferc/ferccid.py
@@ -84,9 +84,7 @@ class FercCIDArchiver(AbstractDatasetArchiver):
 
             # Click the main Download button
             # We specify this exactly to reduce possibility of selecting the wrong button
-            await page.locator(
-                "div.dataAsset div.fields.row div.d-flex.flex-row-reverse.mt-5 button.blueButton"
-            ).click()
+            await page.get_by_role("button", name="Download button").click()
 
             # Wait for the pop-up download menu
             modal = page.locator("#downloadModal")
@@ -131,9 +129,7 @@ class FercCIDArchiver(AbstractDatasetArchiver):
 
             # Click the main Download button
             # We specify this exactly to reduce possibility of selecting the wrong button
-            await page.locator(
-                "div.dataAsset div.fields.row div.d-flex.flex-row-reverse.mt-5 button.blueButton"
-            ).click()
+            await page.get_by_role("button", name="Download button").click()
 
             # Wait for the pop-up download menu
             modal = page.locator("#downloadModal")


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #1187 

What problem does this address?
The FERC CID archiver was failing because a playwright CSS pointer resolved to multiple possible links on a page.

What did you change in this PR?

- This PR fixes this failure by pointing at a more precise download button role, rather than using a CSS selector.
- It also fixes a silent failure where archivers that have test failures of tests not required for run success were reporting as having no changes despite actual changes occurring.

# Testing

How did you make sure this worked? How can a reviewer verify this?
https://github.com/catalyst-cooperative/pudl-archiver/issues/1194

# To-do list

- [x] Review the PR yourself and call out any questions or issues you have

