### PR TITLE
Grab missing versions of usgsuswtdb

### DIFF
--- a/src/pudl_archiver/archivers/usgsuswtdb.py
+++ b/src/pudl_archiver/archivers/usgsuswtdb.py
@@ -24,7 +24,7 @@ class UsgsUswtdbArchiver(AbstractDatasetArchiver):
 
     async def get_resources(self) -> ArchiveAwaitable:
         """Download USWTDB resources."""
-        link_pattern = re.compile(r"uswtdb_v(\d+)_(\d+)(?:_(\d+))?_(\d{8})\.zip")
+        link_pattern = re.compile(r"uswtdb_(?:v|V)(\d+)_(\d+)(?:_(\d+))?_(\d{8})\.zip")
         self.logger.info(f"Searching {BASE_URL} for hyperlinks matching {link_pattern}")
         data_links = await self.get_hyperlinks(BASE_URL, link_pattern)
         for link, name in data_links.items():


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?
An incomplete regex query missed versions on https://www.sciencebase.gov/catalog/item/5e99a01082ce172707f6fd2a that used V instead of v.

What did you change in this PR?
Updated the regex query to include both v and V.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See #1209 and https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/28800063953

# To-do list

- [x] Review the PR yourself and call out any questions or issues you have

