### PR TITLE
Fix ambiguous playwright locator

### DIFF
--- a/src/pudl_archiver/archivers/ferc/ferc_online_helpers.py
+++ b/src/pudl_archiver/archivers/ferc/ferc_online_helpers.py
@@ -33,7 +33,8 @@ async def get_resources_for_form(
         for year in years:
             logging.info(f"Attempting to download ferc{ferc_form} {year}")
             async with page.expect_download() as download_info:
-                await page.get_by_role("link", name=str(year)).click()
+                name = "2021 Q1 & Q2" if year == 2021 else str(year)
+                await page.get_by_role("link", name=name, exact=True).click()
 
             download = await download_info.value
             download_path = download_directory / f"ferc{ferc_form}-{year}.zip"


### PR DESCRIPTION
# Overview

Closes #1251.

## What problem does this address?
#1226 updated FERC dbf archivers to use `playwright` to work with FERC's webapp. During the PR we switched to using role based `locator`s as recommended by `playwright`, but this ended up causing an error every time we tried to download 2013 data due to an ambiguity with another link present on the page. 

## What did you change in this PR?
I've kept role based locators, but removed ambiguity with the `exact=True` argument.

# Testing

Ran locally FERC archivers locally with a selection of years including 2013 (and 2021 as it handled slightly differently in this update).

