### PR TITLE
Split schedules and create distinct issues for PUDL vs non-PUDL GHA runs

### DIFF
--- a/.github/ISSUE_TEMPLATE/monthly-archive-update.md
+++ b/.github/ISSUE_TEMPLATE/monthly-archive-update.md
@@ -1,7 +1,7 @@
 ---
 name: Monthly archive update
 about: Template for publishing monthly archives.
-title: Publish {{ date | date('MMMM Do YYYY') }} archives
+title: Publish {% if RUN_TYPE == 'pudl' %}PUDL {% elsif RUN_TYPE == 'non_pudl' %}non-PUDL {% elsif RUN_TYPE == 'early_final_release' %}EIA early/final release {% endif %}{{ date | date('MMMM Do YYYY') }} archives
 labels: archive-update, zenodo
 assignees: e-belfer
 

--- a/.github/ISSUE_TEMPLATE/monthly-archive-update.md
+++ b/.github/ISSUE_TEMPLATE/monthly-archive-update.md
@@ -1,7 +1,7 @@
 ---
 name: Monthly archive update
 about: Template for publishing monthly archives.
-title: Publish {% if RUN_TYPE == 'pudl' %}PUDL {% elif RUN_TYPE == 'non_pudl' %}non-PUDL {% elif RUN_TYPE == 'early_final_release' %}EIA early/final release {% endif %}{{ date | date('MMMM Do YYYY') }}
+title: Publish {% if RUN_TYPE == 'pudl' %}PUDL {% elif RUN_TYPE == 'non_pudl' %}non-PUDL {% elif RUN_TYPE == 'early_final_release' %}EIA early/final release {% endif %}{{ date | date('MMMM Do YYYY') }} archives
 labels: archive-update, zenodo
 assignees: e-belfer
 

--- a/.github/ISSUE_TEMPLATE/monthly-archive-update.md
+++ b/.github/ISSUE_TEMPLATE/monthly-archive-update.md
@@ -1,7 +1,7 @@
 ---
 name: Monthly archive update
 about: Template for publishing monthly archives.
-title: Publish {% if RUN_TYPE == 'pudl' %}PUDL {% elsif RUN_TYPE == 'non_pudl' %}non-PUDL {% elsif RUN_TYPE == 'early_final_release' %}EIA early/final release {% endif %}{{ date | date('MMMM Do YYYY') }} archives
+title: Publish {% if RUN_TYPE == 'pudl' %}PUDL {% elif RUN_TYPE == 'non_pudl' %}non-PUDL {% elif RUN_TYPE == 'early_final_release' %}EIA early/final release {% endif %}{{ date | date('MMMM Do YYYY') }}
 labels: archive-update, zenodo
 assignees: e-belfer
 

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -57,12 +57,12 @@ jobs:
 
           if [ "$DOW" -eq 7 ] || [ "$DOM" -eq 01 ]; then
           ## On sundays and the 1st of the month, run all PUDL data sources
-            echo 'datasets=["censuspep","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiabluesky","eianems","epacamd_eia","epacems","epamats","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","phmsagas","vcerare"]' >> "$GITHUB_OUTPUT"
+            echo 'datasets=["censuspep","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","epacamd_eia","epacems","epamats","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","nrelatb","phmsagas","vcerare"]' >> "$GITHUB_OUTPUT"
             echo "run_type=pudl" >> "$GITHUB_OUTPUT"
           elif [ "$DOM" -eq 02 ] && [ "$HOUR" -eq 4 ]; then
           ## On the second of the month where the hour is 4AM UTC,
           ## run all non-PUDL data sources.
-            echo 'datasets=["doeiraec","doelead","eiacbecs","eiamecs","eiarecs","eiasteo","eiawater","epaegrid","epapcap","nrelss","nrelsts","usgsuspvdb","usgsuswtdb"]' >> "$GITHUB_OUTPUT"
+            echo 'datasets=["doeiraec","doelead","eiabluesky","eiacbecs","eiamecs","eianems","eiarecs","eiasteo","eiawater","epaegrid","epapcap","mshamines","nrelss","nrelsts","usgsuspvdb","usgsuswtdb"]' >> "$GITHUB_OUTPUT"
             echo "run_type=non_pudl" >> "$GITHUB_OUTPUT"
           else
             # Otherwise, look for the early and final release outputs for EIA datasets

--- a/.github/workflows/run-archiver.yml
+++ b/.github/workflows/run-archiver.yml
@@ -28,9 +28,10 @@ on:
         required: false
         type: boolean
   schedule:
-    - cron: "21 10 1 * *" # 10:21 AM UTC, first of every month
-    - cron: "21 10 * * 0" # 10:21 AM UTC, every Sunday
-    - cron: "21 14 * 6-7,9-10 1-6" # 2:21 PM UTC, every day June-July and Sept-Oct except for Sundays
+    - cron: "21 10 1 * *" # 10:21 AM UTC, first of every month - run all PUDL archivers
+    - cron: "21 10 * * 0" # 10:21 AM UTC, every Sunday - run all PUDL archivers
+    - cron: "21 4 2 * *" # 4:21 AM UTC, every second of the month - run all non-PUDL archivers
+    - cron: "21 14 * 6-7,9-10 1-6" # 2:21 PM UTC, every day June-July and Sept-Oct except for Sundays - look for early and final release of EIA data
 
 jobs:
   determine-datasets:
@@ -38,6 +39,7 @@ jobs:
 
     outputs:
       datasets: ${{ steps.datasets.outputs.datasets }}
+      run_type: ${{ steps.datasets.outputs.run_type }}
 
     steps:
       - id: datasets
@@ -51,13 +53,21 @@ jobs:
 
           DOW=$(date -u +%u) # Get day of week
           DOM=$(date -u +%d) # Get day of month
+          HOUR=$(date -u +%H) # Get hour of month
 
           if [ "$DOW" -eq 7 ] || [ "$DOM" -eq 01 ]; then
-          ## On sundays and the 1st of the month, run the full matrix
-            echo 'datasets=["censuspep","doeiraec","doelead","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiabluesky","eiacbecs","eiamecs","eianems","eiarecs","eiasteo","eiawater","epacamd_eia","epacems","epaegrid","epamats","epapcap","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","nrelss","nrelsts","phmsagas","usgsuspvdb","usgsuswtdb","vcerare"]' >> "$GITHUB_OUTPUT"
+          ## On sundays and the 1st of the month, run all PUDL data sources
+            echo 'datasets=["censuspep","eia176","eia191","eia757a","eia860","eia860m","eia861","eia923","eia930","eiaaeo","eiaapi","eiabluesky","eianems","epacamd_eia","epacems","epamats","ferc1","ferc2","ferc6","ferc60","ferc714","ferccid","gridpathratoolkit","mshamines","nrelatb","phmsagas","vcerare"]' >> "$GITHUB_OUTPUT"
+            echo "run_type=pudl" >> "$GITHUB_OUTPUT"
+          elif [ "$DOM" -eq 02 ] && [ "$HOUR" -eq 4 ]; then
+          ## On the second of the month where the hour is 4AM UTC,
+          ## run all non-PUDL data sources.
+            echo 'datasets=["doeiraec","doelead","eiacbecs","eiamecs","eiarecs","eiasteo","eiawater","epaegrid","epapcap","nrelss","nrelsts","usgsuspvdb","usgsuswtdb"]' >> "$GITHUB_OUTPUT"
+            echo "run_type=non_pudl" >> "$GITHUB_OUTPUT"
           else
-            # Look for the early and final release outputs for EIA datasets
+            # Otherwise, look for the early and final release outputs for EIA datasets
             echo 'datasets=["eia860","eia861","eia923"]' >> "$GITHUB_OUTPUT"
+            echo "run_type=early_final_release" >> "$GITHUB_OUTPUT"
           fi
 
   notify-start:
@@ -262,6 +272,7 @@ jobs:
     needs:
       - archive-run
       - archive-notify
+      - determine-datasets
     steps:
       - uses: actions/checkout@v7
       - name: Create an issue
@@ -275,6 +286,7 @@ jobs:
           CHANGES: ${{ needs.archive-notify.outputs.changes }}
           TIMEDOUT: ${{ needs.archive-notify.outputs.timedout }}
           UNCHANGED: ${{ needs.archive-notify.outputs.unchanged }}
+          RUN_TYPE: ${{ needs.determine-datasets.outputs.run_type }}
         with:
           filename: .github/ISSUE_TEMPLATE/monthly-archive-update.md
       - run: echo "URL=${{ steps.create-issue.outputs.url }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?
Right now PUDL and non-PUDL archivers are run on the same schedule, despite being supported through different funding streams and having different levels of support and maintenance.

What did you change in this PR?
Separate the PUDL vs non-PUDL archive schedules, and create a distinctive issue title to help separate them out. We now have three types of schedules:

- PUDL sources: run on the 1st of the month and Sundays
- Non-PUDL sources: run on the 2nd of the month at a different time (to avoid Sundays on the 2nd of the month causing collisions)
- EIA early and final release: run daily on select months

Each will now create an issue with a distinctive title to help with rapid review of contents.

# Testing

How did you make sure this worked? How can a reviewer verify this?
We can test this with a [manual run](https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/30381131768/job/90350289683) to see that nothing is broken, but we will need to merge this to verify that scheduled behavior works as expected.

Run succeeded: https://github.com/catalyst-cooperative/pudl-archiver/issues/1263

# To-do list

- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

