### PR TITLE
Propagate default ferceqr dataset in scheduled runs

### DIFF
--- a/.github/workflows/run-fsspec-archiver.yml
+++ b/.github/workflows/run-fsspec-archiver.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build launch notification
         id: launch_message
         env:
-          DATASET: ${{ inputs.dataset }}
+          DATASET: ${{ inputs.dataset || 'ferceqr' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
@@ -57,6 +57,7 @@ jobs:
         shell: bash -l {0}
     runs-on: ubuntu-latest
     env:
+      DATASET: ${{ inputs.dataset || 'ferceqr' }}
       DEPOSITION_PATH: ${{ inputs.deposition_path || 'gs://archives.catalyst.coop' }}
     permissions:
       contents: "read"
@@ -87,7 +88,7 @@ jobs:
           pixi run playwright install --with-deps webkit
           pixi run playwright install --with-deps chromium
 
-      - name: Run production archiver for ${{ inputs.dataset }}
+      - name: Run production archiver for ${{ env.DATASET }}
         # set -o pipefail passes on any failure codes to the next step,
         # enabling us to see whether or not the pudl_archiver run failed.
         run: |
@@ -95,24 +96,24 @@ jobs:
           pixi run pudl_archiver \
             archive \
             fsspec \
-            ${{ inputs.dataset }} \
-            "$DEPOSITION_PATH"/${{ inputs.dataset }} \
-            --clobber-unchanged 2>&1 | tee ${{ inputs.dataset }}_log.txt
+            "$DATASET" \
+            "$DEPOSITION_PATH"/"$DATASET" \
+            --clobber-unchanged 2>&1 | tee "${DATASET}_log.txt"
 
       - name: Save failed runs
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: error-log-${{ inputs.dataset }}
-          path: ${{ inputs.dataset }}_log.txt
+          name: error-log-${{ env.DATASET }}
+          path: ${{ env.DATASET }}_log.txt
 
       - name: Upload run summaries
         if: always()
         id: upload_summaries
         uses: actions/upload-artifact@v7
         with:
-          name: run-summaries-${{ inputs.dataset }}
-          path: ${{ inputs.dataset }}_run_summary.json
+          name: run-summaries-${{ env.DATASET }}
+          path: ${{ env.DATASET }}_run_summary.json
 
   archive-notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-fsspec-archiver.yml
+++ b/.github/workflows/run-fsspec-archiver.yml
@@ -24,6 +24,8 @@ on:
 jobs:
   notify-start:
     runs-on: ubuntu-latest
+    outputs:
+      dataset: ${{ steps.launch_message.outputs.DATASET }}
     steps:
       - name: Build launch notification
         id: launch_message
@@ -37,6 +39,7 @@ jobs:
             echo "# :rocket: Launching \`$WORKFLOW_NAME\` workflow ([view run]($RUN_URL))"
             echo
             echo "Dataset: $DATASET"
+            echo "DATASET=$DATASET"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Notify Zulip of workflow launch
@@ -57,7 +60,7 @@ jobs:
         shell: bash -l {0}
     runs-on: ubuntu-latest
     env:
-      DATASET: ${{ inputs.dataset || 'ferceqr' }}
+      DATASET: ${{ needs.notify-start.outputs.dataset }}
       DEPOSITION_PATH: ${{ inputs.deposition_path || 'gs://archives.catalyst.coop' }}
     permissions:
       contents: "read"

--- a/src/pudl_archiver/depositors/fsspec.py
+++ b/src/pudl_archiver/depositors/fsspec.py
@@ -395,9 +395,12 @@ class FsspecDraftDeposition(DraftDeposition):
                 )
                 action = DepositionAction.UPDATE
             else:
+                logger.info(
+                    f"No update for {filename}: local {local_md5} and remote {remote_md5} hashes are identical."
+                )
                 action = DepositionAction.NO_OP
         else:
-            logger.info(f"Adding {filename} to deposition.")
+            logger.info(f"Adding new file {filename} to deposition.")
 
             action = DepositionAction.CREATE
 


### PR DESCRIPTION
# Overview

- The scheduled EQR update on 2026-08-01 failed because the `inputs.dataset` value only gets the default `ferceqr` value when run `on: workflow_dispatch`. In the `on: schedule` case it remains unset, leading to an invalid script invocation.
- I think the `default` value is really just about pre-filling the workflow dispatch UI, so I added a fallback to `ferceqr` in the environments of the jobs that need datasets in the `run-fsspec-archiver.yml` workflow.
- Ideally there would be a way to specify the default in just a single place, rather than several... I think I can get it down to 2 but the UI default has to be a static string.
- Also added a little more detail to the logging that happens during the run so that the "no change" "updated data" and "new file" cases are all clear in the logs.

# Testing

Since `on: schedule` only works from `main` I tested this with the `gh api` CLI, passing in a null dataset:

```console
gh api repos/catalyst-cooperative/pudl-archiver/actions/workflows/run-fsspec-archiver.yml/dispatches \
  -f ref=fix-ferceqr-default -f 'inputs[dataset]='
```

It successfully fell back to the `ferceqr` default resulting in [this archiving job](https://github.com/catalyst-cooperative/pudl-archiver/actions/runs/30720484780/job/91423337410)

# To-do list

- [ ] Review the PR yourself and call out any questions or issues you have

