### PR TITLE
Archive EIA930A data

### DIFF
--- a/src/pudl_archiver/archivers/eia/eia930.py
+++ b/src/pudl_archiver/archivers/eia/eia930.py
@@ -1,8 +1,11 @@
 """Download EIA-930 data."""
 
+import re
 from pathlib import Path
+from urllib.parse import urljoin
 
 import pandas as pd
+from playwright.async_api import async_playwright, expect
 
 from pudl_archiver.archivers.classes import (
     AbstractDatasetArchiver,
@@ -16,6 +19,7 @@ FILE_LIST_URL = "https://www.eia.gov/electricity/gridmonitor/sixMonthFiles/EIA93
 REFERENCE_URL = (
     "https://www.eia.gov/electricity/930-content/EIA930_Reference_Tables.xlsx"
 )
+ABOUT_URL = "https://www.eia.gov/electricity/gridmonitor/about"
 
 
 class Eia930Archiver(AbstractDatasetArchiver):
@@ -23,7 +27,7 @@ class Eia930Archiver(AbstractDatasetArchiver):
 
     name = "eia930"
 
-    async def get_file_list(self) -> pd.DataFrame:
+    async def get_eia930_file_list(self) -> pd.DataFrame:
         """Get EIA 930 file list dataframe."""
         return pd.read_csv(FILE_LIST_URL)
 
@@ -36,11 +40,40 @@ class Eia930Archiver(AbstractDatasetArchiver):
             partitions={"half_year": "all", "form": "reference"},
         )
 
+    async def after_download(self) -> None:
+        """Clean up playwright once downloads are complete."""
+        await self.browser.close()
+        await self.playwright.stop()
+
+    async def get_eia930a_files(self) -> dict[str, str]:
+        """Get a dictionary of EIA 930A file download URLs indexed by year."""
+        link_dict = {}
+        self.playwright = await async_playwright().start()
+        self.browser = await self.playwright.webkit.launch()
+
+        link_pattern = re.compile(r"EIA_930A_(\d{4})_with layout.xlsx")
+        # Get main table links using playwright.
+        page = await self.browser.new_page()
+        await page.goto(ABOUT_URL, timeout=10 * 60 * 1000)
+        await expect(
+            page.get_by_text("About the EIA-930 data")
+        ).to_be_visible()  # Wait for reference URL to load before proceeding.
+        text = await page.content()
+        links = self.get_hyperlinks_from_text(text, link_pattern, ABOUT_URL)
+
+        for link in links:
+            matches = link_pattern.search(link)
+            if not matches:
+                continue
+            year = int(matches.group(1))
+            link_dict.update({year: link})
+        return link_dict
+
     async def get_resources(self) -> ArchiveAwaitable:
         """Download EIA-930 resources."""
-        file_list = await self.get_file_list()
+        eia930_file_list = await self.get_eia930_file_list()
         year_period = (
-            file_list[["YEAR", "PERIOD"]]
+            eia930_file_list[["YEAR", "PERIOD"]]
             .value_counts()
             .reset_index()
             .drop(columns=["count"])
@@ -48,16 +81,25 @@ class Eia930Archiver(AbstractDatasetArchiver):
         )
         for index, period in year_period.iterrows():
             if self.valid_year(period.YEAR):
-                yield self.get_year_resource(
-                    file_list=file_list, year=period.YEAR, half_year=period.PERIOD
+                yield self.get_eia930_half_year_resource(
+                    file_list=eia930_file_list,
+                    year=period.YEAR,
+                    half_year=period.PERIOD,
+                )
+
+        eia930a_file_list = await self.get_eia930a_files()
+        for year in eia930a_file_list:
+            if self.valid_year(year):
+                yield self.get_eia930a_year_resource(
+                    file=eia930a_file_list[year], year=year
                 )
         yield self.get_reference_table()
 
-    async def get_year_resource(
+    async def get_eia930_half_year_resource(
         self, file_list: pd.DataFrame, year=int, half_year=int
     ) -> tuple[Path, dict]:
-        """Download zip file of all files in year."""
-        self.logger.debug(f"Downloading data for {year}half{half_year}.")
+        """Download zip file of all files in a half-year."""
+        self.logger.debug(f"Downloading EIA 930 data for {year}half{half_year}.")
         zip_path = self.download_directory / f"eia930-{year}half{half_year}.zip"
         data_paths_in_archive = set()
         period_files = file_list[
@@ -80,6 +122,28 @@ class Eia930Archiver(AbstractDatasetArchiver):
 
         return ResourceInfo(
             local_path=zip_path,
-            partitions={"half_year": f"{year}half{half_year}"},
+            partitions={"half_year": f"{year}half{half_year}", "form": "eia930"},
+            layout=ZipLayout(file_paths=data_paths_in_archive),
+        )
+
+    async def get_eia930a_year_resource(
+        self, file: str, year=int, half_year=int
+    ) -> tuple[Path, dict]:
+        """Download zip file of all files in year for EIA 930-A."""
+        self.logger.debug(f"Downloading EIA930A data for {year}.")
+        zip_path = self.download_directory / f"eia930a-{year}.zip"
+        data_paths_in_archive = set()
+
+        url = urljoin(ABOUT_URL, file)
+        file_type = url.split(".")[
+            -1
+        ]  # Infer filetype based on url, rather than assigning
+        filename = f"eia930a-{year}.{file_type}"
+        await self.download_and_zip_file(url, filename, zip_path)
+        data_paths_in_archive.add(filename)
+
+        return ResourceInfo(
+            local_path=zip_path,
+            partitions={"year": year, "form": "eia930a"},
             layout=ZipLayout(file_paths=data_paths_in_archive),
         )


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #1258 

What problem does this address?
- Add EIA 930A to archive for all years of available data.

What did you change in this PR?
- Add EIA 930A files as separate zips
- Update partitions to add form for all files
- Use playwright for EIA 930A because links do not immediately appear using existing request based methods.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run the archiver:

# To-do list

- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

