### PR TITLE
Move dataset envvar outside of heredoc

### DIFF
--- a/.github/workflows/run-fsspec-archiver.yml
+++ b/.github/workflows/run-fsspec-archiver.yml
@@ -39,8 +39,8 @@ jobs:
             echo "# :rocket: Launching \`$WORKFLOW_NAME\` workflow ([view run]($RUN_URL))"
             echo
             echo "Dataset: $DATASET"
-            echo "DATASET=$DATASET"
             echo "EOF"
+            echo "DATASET=$DATASET"
           } >> "$GITHUB_OUTPUT"
       - name: Notify Zulip of workflow launch
         uses: zulip/github-actions-zulip/send-message@v2


### PR DESCRIPTION
# Overview

- Fix a cut-and-paste error that put the assignment of the `$DATASET` variable in a python heredoc, rather than in the normal `run` scope of the GitHub action.
- This prevented subsequent jobs from picking up the default `ferceqr` dataset value, causing the scheduled Sept. 1st archive to fail.