### PR TITLE
Fix typo in `eiabluesky` DOI listing

### DIFF
--- a/src/pudl_archiver/package_data/zenodo_doi.yaml
+++ b/src/pudl_archiver/package_data/zenodo_doi.yaml
@@ -40,7 +40,7 @@ eiaaeo:
 eiaapi:
   production_doi: 10.5281/zenodo.7067366
   sandbox_doi: 10.5072/zenodo.2356
-eiablueksy:
+eiabluesky:
   production_doi: 10.5281/zenodo.21629427
   sandbox_doi: 10.5072/zenodo.570294
 eiacbecs:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Fixes issue addressed in #1304

What problem does this address?
A typo in the zenodo_doi.yaml prevents `eiabluesky` archivers from being updated.

What did you change in this PR?
Fixed the typo.

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

- [x] Review the PR yourself and call out any questions or issues you have

